### PR TITLE
Fix a bug giving wrong birth times in dimension 0

### DIFF
--- a/include/persistence.h
+++ b/include/persistence.h
@@ -527,13 +527,13 @@ protected:
 
 		for (auto e : edges) {
 			const auto vertices = complex.vertices_of_edge(get_index(e));
-			index_t u = dset.find(vertices.first), v = dset.find(vertices.second);
-			dset.link(u, v);
+			index_t u = dset.find(vertices.first), v = dset.find(vertices.second);	
 
 			if (u != v) {
 				// Only output bars if we are interested in zeroth homology
 				const auto filtration_u = complex.filtration(0, u);
 				const auto filtration_v = complex.filtration(0, v);
+				dset.link(u, v);
 				if (min_dimension == 0 && get_filtration(e) > std::max(filtration_u, filtration_v)) {
 					// Check which vertex is merged into which other vertex.
 					const auto f = dset.find(u) == u ? filtration_v : filtration_u;

--- a/include/persistence.h
+++ b/include/persistence.h
@@ -528,6 +528,7 @@ protected:
 		for (auto e : edges) {
 			const auto vertices = complex.vertices_of_edge(get_index(e));
 			index_t u = dset.find(vertices.first), v = dset.find(vertices.second);
+			dset.link(u, v);
 
 			if (u != v) {
 				// Only output bars if we are interested in zeroth homology
@@ -538,7 +539,6 @@ protected:
 					const auto f = dset.find(u) == u ? filtration_v : filtration_u;
 					output->new_barcode(f, get_filtration(e));
 				}
-				dset.link(u, v);
 			} else {
 				columns_to_reduce.push_back(e);
 			}


### PR DESCRIPTION
When computing the persistence pairs in dimension 0, and using a filtration such as sum of vertex weights, sometimes the birth time was wrong. 

The reason for this is that dset.link(u, v) was being called to late. On line 539 a test is done to see if u has been merged into v or if v has been merged into u. However, it always finds that dset.find(u)==u as the function dset.link(u, v) has not yet been called.

So I have moved dset.link(u, v) to line 531, which I think fixes the problem.