### PR TITLE
Remove memory leaks

### DIFF
--- a/include/complex/directed_flag_complex.h
+++ b/include/complex/directed_flag_complex.h
@@ -189,7 +189,7 @@ public:
 	void for_each_cell(std::vector<Func>& fs, int min_dimension, int max_dimension = -1) {
 		if (max_dimension == -1) max_dimension = min_dimension;
         size_t number_of_threads = fs.size();
-		std::thread t[number_of_threads - 1];
+        std::vector<std::thread> t(number_of_threads - 1);
 
 		for (size_t index = 0; index < number_of_threads - 1; ++index)
 			t[index] = std::thread(&directed_flag_complex_t::worker_thread<Func>, this, number_of_threads, index,

--- a/include/directed_graph.h
+++ b/include/directed_graph.h
@@ -67,6 +67,7 @@ public:
 	size_t incidence_row_length;
 
 	// Assume by default that the edge density will be roughly one percent
+    directed_graph_t(){}
 	directed_graph_t(vertex_index_t _number_of_vertices, bool directed = true, float density_hint = 0.01)
 	    : number_of_vertices(_number_of_vertices), directed(directed), incidence_row_length((_number_of_vertices >> 6) + 1) {
 		outdegrees.resize(_number_of_vertices, 0);
@@ -126,6 +127,7 @@ public:
 
 	// WARNING: This does not take the filtration into account!
 	// TODO: Think about how to do this efficiently.
+	filtered_directed_graph_t(){}
 	filtered_directed_graph_t(filtered_directed_graph_t* big_graph, std::unordered_set<vertex_index_t> subset)
 	    : filtered_directed_graph_t(std::vector<value_t>(subset.size(), 0), big_graph->directed) {
 		// Add the edges

--- a/include/input/flagser.h
+++ b/include/input/flagser.h
@@ -27,7 +27,7 @@ std::vector<t> split(const std::string& s, char delim, const std::function<t(std
 enum HAS_EDGE_FILTRATION { TOO_EARLY_TO_DECIDE, MAYBE, YES, NO };
 filtered_directed_graph_t read_graph_flagser(const std::string filename, const named_arguments_t& named_arguments) {
 	std::string line;
-	filtered_directed_graph_t* graph;
+	filtered_directed_graph_t graph{};
 	int current_dimension = 0;
 	std::vector<value_t> vertex_filtration;
 	HAS_EDGE_FILTRATION has_edge_filtration = HAS_EDGE_FILTRATION::TOO_EARLY_TO_DECIDE;
@@ -42,7 +42,7 @@ filtered_directed_graph_t read_graph_flagser(const std::string filename, const n
 		if (line.length() == 0) continue;
 		if (line[0] == 'd' && line[1] == 'i' && line[2] == 'm') {
 			if (line[4] == '1') {
-				graph = new filtered_directed_graph_t(vertex_filtration, directed);
+				graph = filtered_directed_graph_t(vertex_filtration, directed);
 				current_dimension = 1;
 				has_edge_filtration = HAS_EDGE_FILTRATION::MAYBE;
 			}
@@ -62,7 +62,7 @@ filtered_directed_graph_t read_graph_flagser(const std::string filename, const n
 
 			if (has_edge_filtration == NO) {
 				std::vector<vertex_index_t> vertices = split<vertex_index_t>(line, ' ', string_to_uint);
-				graph->add_edge(vertices[0], vertices[1]);
+				graph.add_edge(vertices[0], vertices[1]);
 			} else {
 				std::vector<value_t> vertices = split<value_t>(line, ' ', string_to_float);
 				if (vertices[2] < std::max(vertex_filtration[vertices[0]], vertex_filtration[vertices[1]])) {
@@ -73,10 +73,10 @@ filtered_directed_graph_t read_graph_flagser(const std::string filename, const n
 					          << vertex_filtration[vertices[1]] << "), the filtrations of its vertices.";
 					exit(-1);
 				}
-				graph->add_filtered_edge((vertex_index_t)vertices[0], (vertex_index_t)vertices[1], vertices[2]);
+				graph.add_filtered_edge((vertex_index_t)vertices[0], (vertex_index_t)vertices[1], vertices[2]);
 			}
 		}
 	}
 
-	return *graph;
+	return graph;
 }

--- a/include/output/output_classes.h
+++ b/include/output/output_classes.h
@@ -20,19 +20,19 @@ bool has_zero_filtration_and_no_explicit_output(const named_arguments_t& named_a
 	       std::string(get_argument_or_default(named_arguments, "filtration", "zero")) == "zero";
 }
 
-template <typename Complex> output_t<Complex>* get_output(const named_arguments_t& named_arguments) {
+template <typename Complex> output_t<Complex> get_output(const named_arguments_t& named_arguments) {
 	std::string output_name = "barcode";
 	auto it = named_arguments.find("out-format");
 	if (it != named_arguments.end()) { output_name = it->second; }
 
 	if (output_name == "betti" || has_zero_filtration_and_no_explicit_output(named_arguments))
-		return new betti_output_t<Complex>(named_arguments);
-	if (output_name == "barcode") return new barcode_output_t<Complex>(named_arguments);
+		return betti_output_t<Complex>(named_arguments);
+	if (output_name == "barcode") return barcode_output_t<Complex>(named_arguments);
 
-	if (output_name == "none") return new trivial_output_t<Complex>(named_arguments);
+	if (output_name == "none") return trivial_output_t<Complex>(named_arguments);
 
 #ifdef WITH_HDF5
-	if (output_name == "barcode:hdf5") return new barcode_hdf5_output_t<Complex>(named_arguments);
+	if (output_name == "barcode:hdf5") return barcode_hdf5_output_t<Complex>(named_arguments);
 #endif
 
 	std::cerr << "The output format \"" << output_name << "\" could not be found." << std::endl;

--- a/include/persistence.h
+++ b/include/persistence.h
@@ -447,7 +447,7 @@ private:
 template <typename Complex> class persistence_computer_t {
 private:
 	Complex& complex;
-	output_t<Complex>* output;
+	output_t<Complex> output;
 	value_t max_filtration;
 	size_t max_entries;
 	index_t euler_characteristic = 0;
@@ -467,7 +467,7 @@ private:
 #endif
 
 public:
-	persistence_computer_t(Complex& _complex, output_t<Complex>* _output,
+	persistence_computer_t(Complex& _complex, output_t<Complex> _output,
 	                       size_t _max_entries = std::numeric_limits<size_t>::max(), int _modulus = 2,
 	                       value_t _max_filtration = std::numeric_limits<value_t>::max())
 	    : complex(_complex), output(_output), max_filtration(_max_filtration), max_entries(_max_entries),
@@ -484,7 +484,7 @@ public:
 		compute_zeroth_persistence(min_dimension, max_dimension);
 		compute_higher_persistence(min_dimension, max_dimension);
 		complex.finished();
-		output->finished(check_euler_characteristic);
+		output.finished(check_euler_characteristic);
 
 		// Sanity check whether there were any problems computing the homology
 		bool computed_full_homology = min_dimension == 0 && max_dimension == std::numeric_limits<unsigned short>::max();
@@ -553,7 +553,7 @@ protected:
 		std_algorithms::sort(edges.rbegin(), edges.rend(), greater_filtration_or_smaller_index<filtration_index_t>());
 
 		// Let the output class know that we are now computing zeroth degree barcodes
-		output->computing_barcodes_in_dimension(0);
+		output.computing_barcodes_in_dimension(0);
 
 		for (auto e : edges) {
 			const auto vertices = complex.vertices_of_edge(get_index(e));
@@ -567,7 +567,7 @@ protected:
 				if (min_dimension == 0 && get_filtration(e) > std::max(filtration_u, filtration_v)) {
 					// Check which vertex is merged into which other vertex.
 					const auto f = dset.find(u) == u ? filtration_v : filtration_u;
-					output->new_barcode(f, get_filtration(e));
+					output.new_barcode(f, get_filtration(e));
 #ifdef RETRIEVE_PERSISTENCE
 					birth_death.push_back(std::make_pair(f, get_filtration(e)));
 #endif
@@ -591,7 +591,7 @@ protected:
 
 		for (index_t index = 0; index < n; ++index) {
 			if (dset.find(index) == index) {
-				output->new_infinite_barcode(complex.filtration(0, index));
+				output.new_infinite_barcode(complex.filtration(0, index));
 				betti_number++;
 #ifdef RETRIEVE_PERSISTENCE
 				birth_death.push_back(
@@ -606,7 +606,7 @@ protected:
 #endif
 		// Report the betti number back to the complex and the output
 		complex.computation_result(0, betti_number, 0);
-		output->betti_number(betti_number, 0);
+		output.betti_number(betti_number, 0);
 
 		if (print_betti_numbers_to_console) {
 			std::cout << "\033[K"
@@ -631,7 +631,7 @@ protected:
 
 			if (dimension + 1 < min_dimension) continue;
 
-			output->computing_barcodes_in_dimension(dimension);
+			output.computing_barcodes_in_dimension(dimension);
 
 			sort_columns();
 
@@ -652,7 +652,7 @@ protected:
 #ifdef RETRIEVE_PERSISTENCE
 				betti_numbers.push_back(betti.first);
 #endif
-				output->betti_number(betti.first, betti.second);
+				output.betti_number(betti.first, betti.second);
 				euler_characteristic += (dimension & 1 ? -1 : 1) * betti.first;
 
 				if (print_betti_numbers_to_console) {
@@ -670,7 +670,7 @@ protected:
 
 			// Stop early
 			if (complex.is_top_dimension()) {
-				output->remaining_homology_is_trivial();
+				output.remaining_homology_is_trivial();
 				break;
 			}
 		}
@@ -849,7 +849,7 @@ protected:
 
 				if (iterations > max_entries) {
 					// Abort, this is too expensive
-					if (generate_output) output->skipped_column(filtration);
+					if (generate_output) output.skipped_column(filtration);
 #ifdef RETRIEVE_PERSISTENCE
 					birth_death.push_back(
 					    std::make_pair(filtration, std::numeric_limits<value_t>::signaling_NaN()));
@@ -878,7 +878,7 @@ protected:
 #endif
 				} else {
 					if (generate_output) {
-						output->new_infinite_barcode(filtration);
+						output.new_infinite_barcode(filtration);
 						betti++;
 #ifdef RETRIEVE_PERSISTENCE
 						birth_death.push_back(std::make_pair(filtration, std::numeric_limits<value_t>::infinity()));
@@ -890,7 +890,7 @@ protected:
 			found_persistence_pair:
 				value_t death = get_filtration(pivot);
 				if (generate_output && filtration != death) {
-					output->new_barcode(filtration, death);
+					output.new_barcode(filtration, death);
 #ifdef RETRIEVE_PERSISTENCE
 					birth_death.push_back(std::make_pair(filtration, death));
 #endif

--- a/src/flagser-count.cpp
+++ b/src/flagser-count.cpp
@@ -88,17 +88,17 @@ void count_cells(filtered_directed_graph_t& graph, const named_arguments_t& name
 			std::vector<size_t> cell_counts;
 		};
 
-		std::array<cell_counter_t*, PARALLEL_THREADS> cell_counter;
+		std::vector<cell_counter_t> cell_counter(PARALLEL_THREADS);
 		for (int i = 0; i < PARALLEL_THREADS; i++)
-			cell_counter[i] = new cell_counter_t(
+			cell_counter.push_back(cell_counter_t(
 #ifdef WITH_HDF5
 			    output
 #endif
-			);
+			));
 
 #ifdef WITH_HDF5
 		if (output != nullptr)
-			complex.for_each_cell(*cell_counter[0], 0, 10000);
+			complex.for_each_cell(*cell_counter.data(), 0, 10000);
 		else {
 #endif
 			complex.for_each_cell(cell_counter, 0, 10000);
@@ -106,7 +106,7 @@ void count_cells(filtered_directed_graph_t& graph, const named_arguments_t& name
 		}
 #endif
 		int64_t euler_characteristic = 0;
-		for (int i = 0; i < PARALLEL_THREADS; i++) euler_characteristic += cell_counter[i]->euler_characteristic();
+		for (int i = 0; i < PARALLEL_THREADS; i++) euler_characteristic += cell_counter[i].euler_characteristic();
 
 #ifdef INDICATE_PROGRESS
 		std::cout << "\033[K";
@@ -118,7 +118,7 @@ void count_cells(filtered_directed_graph_t& graph, const named_arguments_t& name
 		std::array<std::vector<size_t>, PARALLEL_THREADS> cell_counts;
 		size_t max_dim = 0;
 		for (int i = 0; i < PARALLEL_THREADS; i++) {
-			cell_counts[i] = cell_counter[i]->cell_count();
+			cell_counts[i] = cell_counter[i].cell_count();
 			size_t dim = cell_counts[i].size();
 			max_dim = max_dim < dim ? dim : max_dim;
 		}

--- a/src/flagser.cpp
+++ b/src/flagser.cpp
@@ -63,12 +63,12 @@ compute_homology(filtered_directed_graph_t& graph, const named_arguments_t& name
 	for (auto subgraph : subgraphs) {
 		directed_flag_complex_compute_t complex(subgraph, named_arguments);
 
-		output->set_complex(&complex);
+		output.set_complex(&complex);
 		if (split_into_connected_components) {
-			if (component_number > 1) output->print("\n");
-			output->print("## Path component number ");
-			output->print(std::to_string(component_number));
-			output->print("\n");
+			if (component_number > 1) output.print("\n");
+			output.print("## Path component number ");
+			output.print(std::to_string(component_number));
+			output.print("\n");
 
 #ifdef INDICATE_PROGRESS
 			std::cout << "\033[K";
@@ -88,12 +88,12 @@ compute_homology(filtered_directed_graph_t& graph, const named_arguments_t& name
 #endif
 	}
 
-	if (split_into_connected_components) { output->print("\n## Total\n"); }
+	if (split_into_connected_components) { output.print("\n## Total\n"); }
 
-	output->print_aggregated_results();
+	output.print_aggregated_results();
 
     // Closes output files, prevent memory leaks
-    delete output;
+    // delete output;
 
 #ifdef RETRIEVE_PERSISTENCE
 	return complex_subgraphs;

--- a/src/ripser.cpp
+++ b/src/ripser.cpp
@@ -575,10 +575,10 @@ int main(int argc, char** argv) {
 
 
 	vietoris_rips_complex_t<decltype(dist)> vietoris_rips_complex(dist, dim_max, modulus);
-	auto* output = get_output<decltype(vietoris_rips_complex)>(named_arguments);
-  output->set_complex(&vietoris_rips_complex);
+	auto output = get_output<decltype(vietoris_rips_complex)>(named_arguments);
+  output.set_complex(&vietoris_rips_complex);
 
 	persistence_computer_t<decltype(vietoris_rips_complex)> persistence_computer(vietoris_rips_complex, output, max_entries, modulus, threshold);
 	persistence_computer.compute_persistence(dim_min, dim_max, false);
-	output->print_aggregated_results();
+	output.print_aggregated_results();
 }

--- a/test/run3
+++ b/test/run3
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+import subprocess
+import os
+import sys
+import re
+
+tests = {
+    'd2': [1, 1],
+    'a': [1, 2, 0],
+    'b': [1, 0, 0],
+    'c': [1, 5],
+    'd': [1, 0, 1],
+    'e': [1, 0, 0, 0],
+    'f': [1, 0, 0],
+    'd3': [1, 0, 2],
+    'd3-allzero': [1, 0, 2],
+    'double-d3': [1, 0, 5],
+    'double-d3-allzero': [1, 0, 5],
+    'd4': [1, 0, 0, 9],
+    'd4-allzero': [1, 0, 0, 9],
+    'd5': [1, 0, 0, 0, 44],
+    'd7': [1, 0, 0, 0, 0, 0, 1854],
+    'medium-test-data': [14237, 39477, 378, 0],
+    'd10': [1, 0, 0, 0, 0, 0, 0, 0, 0, 1334961]
+}
+
+zero_filtration = ['d3-allzero', 'double-d3-allzero', 'd4-allzero']
+
+for filename, hom in tests.items():
+    print('Testing {filename}.flag...{spaces}\t\t'.format(
+        filename=filename, spaces=(25 - len(filename)) * ' '), end='')
+    try:
+        os.remove('test/tmp')
+    except OSError:
+        pass
+
+    result = subprocess.Popen(
+        './flagser --out ./test/tmp --filtration {alg} ./test/{filename}.flag'.format(
+            alg="zero" if filename in zero_filtration else "max", filename=filename),
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT).stdout.readlines()
+
+    result2 = []
+    for a in result:
+       result2.append(a.decode())
+
+    result = result2
+    result = ''.join(result).replace(',', '')
+
+    success = True
+    try:
+        for idx, val in enumerate(hom):
+            if re.search('dim H_{dim} = {rank}'.format(dim=idx, rank=val), result) == None:
+                # The computation was wrong
+                computed_rank = re.search(
+                    'dim H_{dim} = (.*)$'.format(dim=idx), result, re.M).group(1)
+                print('\x1b[0;31m' + 'Failure 𐄂' + '\x1b[0m')
+                print('')
+                print('\x1b[0;31m' + 'The rank of H_{dim} should have been {rank}, but flagser computed {computed_rank}:'.format(
+                    dim=idx, rank=val, computed_rank=computed_rank) + '\x1b[0m')
+                print('\x1b[2m')
+                sys.stdout.write(result)
+                print('\x1b[0m')
+                success = False
+                break
+    except:
+        success = False
+
+    if success:
+        print('\x1b[0;32m' + 'Success ✔' + '\x1b[0m')
+    else:
+        print('\x1b[0\33[91m' + 'Failure ❌' + '\x1b[0m')
+
+# Cleanup
+try:
+    os.remove('test/tmp')
+except OSError:
+    pass

--- a/test/test_end2end.cpp
+++ b/test/test_end2end.cpp
@@ -34,7 +34,7 @@ void compute(std::string&& filename, std::vector<size_t> homology) {
 	size_t component_number = 1;
   directed_flag_complex_computer_t complex(graph, named_arguments);
 
-  output->set_complex(&complex);
+  output.set_complex(&complex);
 
   auto result = persistence_computer_t<decltype(complex)>(complex, output, max_entries, modulus);
   result.compute_persistence(min_dimension, max_dimension);


### PR DESCRIPTION
This PR:
* fixes some memory leaks.
* Remove unnecessary `new` operator
* Replace passing by pointer to passing by reference
* Update test for python3 compatibility
* Only performed changes for the standard version, I did not update the `KEEP_FLAG_COMPLEX_IN_MEMORY` related files

About the memory leaks found, running `valgrind` profiler to detect memory leaks returned the following summary running over dataset `d5.flag` with filtration zero:

```bash
==21845== LEAK SUMMARY:
==21845==    definitely lost: 216 bytes in 1 blocks
==21845==    indirectly lost: 436 bytes in 7 blocks
==21845==      possibly lost: 0 bytes in 0 blocks
==21845==    still reachable: 1,856 bytes in 2 blocks
==21845==         suppressed: 0 bytes in 0 blocks
==21845==
==21845== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
==21845== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

After my changes, I obtain:

```bash
==22084== LEAK SUMMARY:
==22084==    definitely lost: 0 bytes in 0 blocks
==22084==    indirectly lost: 0 bytes in 0 blocks
==22084==      possibly lost: 0 bytes in 0 blocks
==22084==    still reachable: 1,856 bytes in 2 blocks
==22084==         suppressed: 0 bytes in 0 blocks
==22084==
==22084== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==22084== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

The still reachable part is related to `hdf5`:

```bash
==22084== 8 bytes in 1 blocks are still reachable in loss record 1 of 2
==22084==    at 0x4C31B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==22084==    by 0x50C09FE: H5TS_cancel_count_inc (in /usr/lib/x86_64-linux-gnu/libhdf5_serial.so.100.0.1)
==22084==    by 0x4E711CD: H5open (in /usr/lib/x86_64-linux-gnu/libhdf5_serial.so.100.0.1)
==22084==    by 0x12384D: __static_initialization_and_destruction_0(int, int) [clone .constprop.1328] (in /home/julian/workspace/TWS/flagser_github/flagser)
==22084==    by 0x123CD8: _GLOBAL__sub_I__Z24get_positional_argumentsRKSt4pairISt6vectorIPKcSaIS2_EESt13unordered_mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES2_St4hashISB_ESt8equal_toISB_ESaIS_IKSB_S2_EEEE (in /home/julian/workspace/TWS/flagser_github/flagser)
==22084==    by 0x1580DC: __libc_csu_init (in /home/julian/workspace/TWS/flagser_github/flagser)
==22084==    by 0x5B75B27: (below main) (libc-start.c:266)

==22084== 1,848 bytes in 1 blocks are still reachable in loss record 2 of 2
==22084==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==22084==    by 0x4EF6121: H5E_get_stack (in /usr/lib/x86_64-linux-gnu/libhdf5_serial.so.100.0.1)
==22084==    by 0x4EFAD64: H5E_clear_stack (in /usr/lib/x86_64-linux-gnu/libhdf5_serial.so.100.0.1)
==22084==    by 0x4EF87A6: H5Eget_auto2 (in /usr/lib/x86_64-linux-gnu/libhdf5_serial.so.100.0.1)
==22084==    by 0x4E6F9D1: H5_term_library (in /usr/lib/x86_64-linux-gnu/libhdf5_serial.so.100.0.1)
==22084==    by 0x5B97040: __run_exit_handlers (exit.c:108)
==22084==    by 0x5B97139: exit (exit.c:139)
==22084==    by 0x5B75B9D: (below main) (libc-start.c:344)
```

This seems to be a false positive according to [HDF Group](https://support.hdfgroup.org/HDF5/faq/valgrind.html).
