### PR TITLE
Fix regression introduced in 1a6d896

### DIFF
--- a/include/output/output_classes.h
+++ b/include/output/output_classes.h
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <iostream>
+#include <memory>
 
 #include "../definitions.h"
 
@@ -20,19 +21,19 @@ bool has_zero_filtration_and_no_explicit_output(const named_arguments_t& named_a
 	       std::string(get_argument_or_default(named_arguments, "filtration", "zero")) == "zero";
 }
 
-template <typename Complex> output_t<Complex> get_output(const named_arguments_t& named_arguments) {
+template <typename Complex> std::unique_ptr<output_t<Complex>> get_output(const named_arguments_t& named_arguments) {
 	std::string output_name = "barcode";
 	auto it = named_arguments.find("out-format");
 	if (it != named_arguments.end()) { output_name = it->second; }
 
 	if (output_name == "betti" || has_zero_filtration_and_no_explicit_output(named_arguments))
-		return betti_output_t<Complex>(named_arguments);
-	if (output_name == "barcode") return barcode_output_t<Complex>(named_arguments);
+		return std::make_unique<betti_output_t<Complex>>(named_arguments);
+	if (output_name == "barcode") return std::make_unique<barcode_output_t<Complex>>(named_arguments);
 
-	if (output_name == "none") return trivial_output_t<Complex>(named_arguments);
+	if (output_name == "none") return std::make_unique<trivial_output_t<Complex>>(named_arguments);
 
 #ifdef WITH_HDF5
-	if (output_name == "barcode:hdf5") return barcode_hdf5_output_t<Complex>(named_arguments);
+	if (output_name == "barcode:hdf5") return std::make_unique<barcode_hdf5_output_t<Complex>>(named_arguments);
 #endif
 
 	std::cerr << "The output format \"" << output_name << "\" could not be found." << std::endl;

--- a/include/output/output_classes.h
+++ b/include/output/output_classes.h
@@ -21,7 +21,8 @@
  */
 #define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 
-#if (defined(__GNUC__) || defined(__GNUG__)) && GCC_VERSION < 40900
+// aparently clang defines also gnuc as macros, need to check first for clang
+#if !defined(__clang__) && (defined(__GNUC__) || defined(__GNUG__)) && GCC_VERSION < 40900
 template <typename T, typename... Args> std::unique_ptr<T> make_unique(Args&&... args) {
 	return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }

--- a/include/output/output_classes.h
+++ b/include/output/output_classes.h
@@ -19,14 +19,11 @@
 /* issues with compiler version and std::make_unique were discovered
  * see: https://github.com/luetge/flagser/pull/20
  */
-#define GCC_VERSION (__GNUC__ * 10000 \
-                     + __GNUC_MINOR__ * 100 \
-                     + __GNUC_PATCHLEVEL__)
+#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 
 #if GCC_VERSION < 40900
-template<typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args&&... args) {
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+template <typename T, typename... Args> std::unique_ptr<T> make_unique(Args&&... args) {
+	return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 #endif
 

--- a/include/output/output_classes.h
+++ b/include/output/output_classes.h
@@ -33,18 +33,22 @@ bool has_zero_filtration_and_no_explicit_output(const named_arguments_t& named_a
 }
 
 template <typename Complex> std::unique_ptr<output_t<Complex>> get_output(const named_arguments_t& named_arguments) {
+    // using std namespace because of std::make_unique workaround
+    // This restrict the scope to inside the function
+    using namespace std;
+
 	std::string output_name = "barcode";
 	auto it = named_arguments.find("out-format");
 	if (it != named_arguments.end()) { output_name = it->second; }
 
 	if (output_name == "betti" || has_zero_filtration_and_no_explicit_output(named_arguments))
-		return std::make_unique<betti_output_t<Complex>>(named_arguments);
-	if (output_name == "barcode") return std::make_unique<barcode_output_t<Complex>>(named_arguments);
+		return make_unique<betti_output_t<Complex>>(named_arguments);
+	if (output_name == "barcode") return make_unique<barcode_output_t<Complex>>(named_arguments);
 
-	if (output_name == "none") return std::make_unique<trivial_output_t<Complex>>(named_arguments);
+	if (output_name == "none") return make_unique<trivial_output_t<Complex>>(named_arguments);
 
 #ifdef WITH_HDF5
-	if (output_name == "barcode:hdf5") return std::make_unique<barcode_hdf5_output_t<Complex>>(named_arguments);
+	if (output_name == "barcode:hdf5") return make_unique<barcode_hdf5_output_t<Complex>>(named_arguments);
 #endif
 
 	std::cerr << "The output format \"" << output_name << "\" could not be found." << std::endl;

--- a/include/output/output_classes.h
+++ b/include/output/output_classes.h
@@ -21,7 +21,7 @@
  */
 #define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 
-#if GCC_VERSION < 40900
+#if (defined(__GNUC__) || defined(__GNUG__)) && GCC_VERSION < 40900
 template <typename T, typename... Args> std::unique_ptr<T> make_unique(Args&&... args) {
 	return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }

--- a/include/output/output_classes.h
+++ b/include/output/output_classes.h
@@ -16,6 +16,20 @@
 #include "barcode_hdf5.h"
 #endif
 
+/* issues with compiler version and std::make_unique were discovered
+ * see: https://github.com/luetge/flagser/pull/20
+ */
+#define GCC_VERSION (__GNUC__ * 10000 \
+                     + __GNUC_MINOR__ * 100 \
+                     + __GNUC_PATCHLEVEL__)
+
+#if GCC_VERSION < 40900
+template<typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args) {
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+#endif
+
 bool has_zero_filtration_and_no_explicit_output(const named_arguments_t& named_arguments) {
 	return strlen(get_argument_or_default(named_arguments, "out-format", "")) == 0 &&
 	       std::string(get_argument_or_default(named_arguments, "filtration", "zero")) == "zero";

--- a/src/flagser.cpp
+++ b/src/flagser.cpp
@@ -63,12 +63,12 @@ compute_homology(filtered_directed_graph_t& graph, const named_arguments_t& name
 	for (auto subgraph : subgraphs) {
 		directed_flag_complex_compute_t complex(subgraph, named_arguments);
 
-		output.set_complex(&complex);
+		output->set_complex(&complex);
 		if (split_into_connected_components) {
-			if (component_number > 1) output.print("\n");
-			output.print("## Path component number ");
-			output.print(std::to_string(component_number));
-			output.print("\n");
+			if (component_number > 1) output->print("\n");
+			output->print("## Path component number ");
+			output->print(std::to_string(component_number));
+			output->print("\n");
 
 #ifdef INDICATE_PROGRESS
 			std::cout << "\033[K";
@@ -80,20 +80,17 @@ compute_homology(filtered_directed_graph_t& graph, const named_arguments_t& name
 		}
 
 #ifdef RETRIEVE_PERSISTENCE
-		complex_subgraphs.push_back(persistence_computer_t<decltype(complex)>(complex, output, max_entries, modulus));
+		complex_subgraphs.push_back(persistence_computer_t<decltype(complex)>(complex, output.get(), max_entries, modulus));
 		complex_subgraphs.back().compute_persistence(min_dimension, max_dimension);
 #else
-		persistence_computer_t<decltype(complex)> persistence_computer(complex, output, max_entries, modulus);
+		persistence_computer_t<decltype(complex)> persistence_computer(complex, output.get(), max_entries, modulus);
 		persistence_computer.compute_persistence(min_dimension, max_dimension);
 #endif
 	}
 
-	if (split_into_connected_components) { output.print("\n## Total\n"); }
+	if (split_into_connected_components) { output->print("\n## Total\n"); }
 
-	output.print_aggregated_results();
-
-    // Closes output files, prevent memory leaks
-    // delete output;
+	output->print_aggregated_results();
 
 #ifdef RETRIEVE_PERSISTENCE
 	return complex_subgraphs;

--- a/src/ripser.cpp
+++ b/src/ripser.cpp
@@ -577,9 +577,9 @@ int main(int argc, char** argv) {
 
 	vietoris_rips_complex_t<decltype(dist)> vietoris_rips_complex(dist, dim_max, modulus);
 	auto output = get_output<decltype(vietoris_rips_complex)>(named_arguments);
-  output.set_complex(&vietoris_rips_complex);
+    output->set_complex(&vietoris_rips_complex);
 
-	persistence_computer_t<decltype(vietoris_rips_complex)> persistence_computer(vietoris_rips_complex, output, max_entries, modulus, threshold);
+	persistence_computer_t<decltype(vietoris_rips_complex)> persistence_computer(vietoris_rips_complex, output.get(), max_entries, modulus, threshold);
 	persistence_computer.compute_persistence(dim_min, dim_max, false);
-	output.print_aggregated_results();
+	output->print_aggregated_results();
 }

--- a/test/base.h
+++ b/test/base.h
@@ -19,9 +19,9 @@ void compute(std::string&& filename, std::vector<size_t> homology) {
 	auto output = get_output<directed_flag_complex_computer_t>(named_arguments);
   directed_flag_complex_computer_t complex(graph, named_arguments);
 
-  output.set_complex(&complex);
+  output->set_complex(&complex);
 
-  auto result = persistence_computer_t<decltype(complex)>(complex, output, max_entries, modulus);
+  auto result = persistence_computer_t<decltype(complex)>(complex, output.get(), max_entries, modulus);
   result.compute_persistence(min_dimension, max_dimension);
 
   bool correct = true;


### PR DESCRIPTION
This PR fixes a regression introduced by 1a6d896.
`output_t` is a base class, to access the derived classes, you need a pointer, sorry I made a big mistake here ...

I checked others changes, I did not see any other regressions.

But IMO, before merging this PR, adding test on the persistence found in the output.