### PR TITLE
Add arguments class to manage inputs parameters

### DIFF
--- a/include/complex/directed_flag_complex_in_memory.h
+++ b/include/complex/directed_flag_complex_in_memory.h
@@ -9,6 +9,7 @@
 
 #include "../definitions.h"
 #include "../directed_graph.h"
+#include "../parameters.h"
 
 //
 // Loading the whole complex into memory, trading memory for computation speed

--- a/include/complex/directed_flag_complex_in_memory_computer.h
+++ b/include/complex/directed_flag_complex_in_memory_computer.h
@@ -177,14 +177,10 @@ class directed_flag_complex_in_memory_computer_t {
 	coefficient_t modulus;
 
 public:
-	directed_flag_complex_in_memory_computer_t(filtered_directed_graph_t& _graph,
-	                                           const named_arguments_t& named_arguments)
-	    : graph(_graph), flag_complex(graph),
-	      filtration_algorithm(get_filtration_computer(get_argument_or_default(named_arguments, "filtration", "zero"))),
-	      min_dimension(atoi(get_argument_or_default(named_arguments, "min-dim", "0"))),
-	      max_dimension(atoi(get_argument_or_default(named_arguments, "max-dim", "65535"))),
-	      cache(get_argument_or_default(named_arguments, "cache", "")),
-	      modulus(atoi(get_argument_or_default(named_arguments, "modulus", "2"))) {
+	directed_flag_complex_in_memory_computer_t(filtered_directed_graph_t& _graph, const flagser_parameters& params)
+	    : graph(_graph), flag_complex(graph), filtration_algorithm(params.filtration_algorithm.get()),
+	      min_dimension(params.min_dimension), max_dimension(params.max_dimension), cache(params.cache.c_str()),
+	      modulus(params.modulus) {
 		cell_count.push_back(_graph.vertex_number());
 		cell_count.push_back(_graph.edge_number());
 

--- a/include/input/flagser.h
+++ b/include/input/flagser.h
@@ -9,6 +9,7 @@
 
 #endif
 
+#include "../parameters.h"
 #include "base.h"
 
 // String to number conversion
@@ -24,13 +25,12 @@ std::vector<t> split(const std::string& s, char delim, const std::function<t(std
 }
 
 enum HAS_EDGE_FILTRATION { TOO_EARLY_TO_DECIDE, MAYBE, YES, NO };
-filtered_directed_graph_t read_graph_flagser(const std::string filename, const named_arguments_t& named_arguments) {
+filtered_directed_graph_t read_graph_flagser(const std::string filename, const flagser_parameters& params) {
 	std::string line;
 	filtered_directed_graph_t graph{};
 	int current_dimension = 0;
 	std::vector<value_t> vertex_filtration;
 	HAS_EDGE_FILTRATION has_edge_filtration = HAS_EDGE_FILTRATION::TOO_EARLY_TO_DECIDE;
-	bool directed = std::string(get_argument_or_default(named_arguments, "undirected", "directed")) != "true";
 
 	std::ifstream input_stream;
 	open_file(filename, input_stream);
@@ -41,7 +41,7 @@ filtered_directed_graph_t read_graph_flagser(const std::string filename, const n
 		if (line.length() == 0) continue;
 		if (line[0] == 'd' && line[1] == 'i' && line[2] == 'm') {
 			if (line[4] == '1') {
-				graph = filtered_directed_graph_t(vertex_filtration, directed);
+				graph = filtered_directed_graph_t(vertex_filtration, params.directed);
 				current_dimension = 1;
 				has_edge_filtration = HAS_EDGE_FILTRATION::MAYBE;
 			}

--- a/include/input/h5.h
+++ b/include/input/h5.h
@@ -17,6 +17,8 @@ filtered_directed_graph_t read_graph_h5(const std::string, const named_arguments
 #include <regex>
 #include <string>
 
+#include "../parameters.h"
+
 std::string replace_string(std::string subject, const std::string& search, const std::string& replace) {
 	size_t pos = 0;
 	while ((pos = subject.find(search, pos)) != std::string::npos) {
@@ -68,13 +70,12 @@ herr_t extract_groups(hid_t, const char* name, const H5L_info_t*, void* opdata) 
 	return (*extractor)(name);
 }
 
-const filtered_directed_graph_t read_graph_h5(const std::string filename, const named_arguments_t& named_arguments) {
+const filtered_directed_graph_t read_graph_h5(const std::string filename, const flagser_parameters& params) {
 	filtered_directed_graph_t* graph;
 	std::vector<value_t> vertex_filtration;
-	std::string type = get_argument_or_default(named_arguments, "h5-type", "matrix");
-	bool directed = std::string(get_argument_or_default(named_arguments, "undirected", "directed")) != "true";
-	bool with_filtration = std::string(get_argument_or_default(named_arguments, "filtration",
-	                                                           "no-filtration-specified")) != "no-filtration-specified";
+	std::string type = params.hdf5_type;
+	bool directed = params.directed;
+	bool with_filtration = params.filtration_algorithm.get() != nullptr;
 
 	size_t h5_pos = filename.rfind(".h5");
 	std::string fname = filename;

--- a/include/input/h5.h
+++ b/include/input/h5.h
@@ -4,7 +4,7 @@
 
 #ifndef WITH_HDF5
 
-filtered_directed_graph_t read_graph_h5(const std::string, const named_arguments_t&) {
+filtered_directed_graph_t read_graph_h5(const std::string, const flagser_parameters&) {
 	std::cerr << "Error: flagser was compiled without support for .h5-files. Please install the HDF5-library "
 	             "(https://support.hdfgroup.org/HDF5/) and rebuild flagser by running \"make\" again."
 	          << std::endl;

--- a/include/input/input_classes.h
+++ b/include/input/input_classes.h
@@ -18,10 +18,6 @@ filtered_directed_graph_t read_filtered_directed_graph(std::string input_filenam
 	          << "reading in the graph" << std::flush << "\r";
 #endif
 
-	/** FIXME: I removed the condition about check if in-format was passed
-	 * this means that we use HDF5 if the file end with .h5 and no in-format is
-	 * passed
-	 */
 	if (params.input_format == "h5" || params.hdf5_type.size() > 0 ||
 	    (input_filename.rfind(".h5") != std::string::npos)) {
 		return read_graph_h5(input_filename, params);

--- a/include/input/input_classes.h
+++ b/include/input/input_classes.h
@@ -7,32 +7,32 @@
 #include "../argparser.h"
 #include "../definitions.h"
 #include "../directed_graph.h"
+#include "../parameters.h"
 
 #include "flagser.h"
 #include "h5.h"
 
-filtered_directed_graph_t read_filtered_directed_graph(std::string input_filename,
-                                                       const named_arguments_t& named_arguments) {
-	std::string input_name = "flagser";
-	auto it = named_arguments.find("in-format");
-	if (it != named_arguments.end()) { input_name = it->second; }
-
+filtered_directed_graph_t read_filtered_directed_graph(std::string input_filename, const flagser_parameters& params) {
 #ifdef INDICATE_PROGRESS
 	std::cout << "\033[K"
 	          << "reading in the graph" << std::flush << "\r";
 #endif
 
-	if (input_name == "h5" || strlen(get_argument_or_default(named_arguments, "h5-type", "")) > 0 ||
-	    (!argument_was_passed(named_arguments, "in-format") && input_filename.rfind(".h5") != std::string::npos)) {
-		return read_graph_h5(input_filename, named_arguments);
+	/** FIXME: I removed the condition about check if in-format was passed
+	 * this means that we use HDF5 if the file end with .h5 and no in-format is
+	 * passed
+	 */
+	if (params.input_format == "h5" || params.hdf5_type.size() > 0 ||
+	    (input_filename.rfind(".h5") != std::string::npos)) {
+		return read_graph_h5(input_filename, params);
 	}
-	if (input_name == "flagser") return read_graph_flagser(input_filename, named_arguments);
+	if (params.input_format == "flagser") return read_graph_flagser(input_filename, params);
 
 #ifdef INDICATE_PROGRESS
 	std::cout << "\033[K";
 #endif
 
-	std::cerr << "The input format \"" << input_name << "\" could not be found." << std::endl;
+	std::cerr << "The input format \"" << params.input_format << "\" could not be found." << std::endl;
 	exit(1);
 }
 

--- a/include/output/barcode.h
+++ b/include/output/barcode.h
@@ -4,6 +4,7 @@
 
 #include "../argparser.h"
 #include "../definitions.h"
+#include "../parameters.h"
 #include "base.h"
 
 template <typename Complex> class barcode_output_t : public file_output_t<Complex> {
@@ -17,11 +18,9 @@ template <typename Complex> class barcode_output_t : public file_output_t<Comple
 	index_t euler_characteristic = 0;
 
 public:
-	barcode_output_t(const named_arguments_t& named_arguments)
-	    : file_output_t<Complex>(named_arguments),
-	      min_dimension(atoi(get_argument_or_default(named_arguments, "min-dim", "0"))),
-	      max_dimension(atoi(get_argument_or_default(named_arguments, "max-dim", "65535"))),
-	      modulus(atoi(get_argument_or_default(named_arguments, "modulus", "2"))) {}
+	barcode_output_t(const flagser_parameters& params)
+	    : file_output_t<Complex>(params.output_name), min_dimension(params.min_dimension),
+	      max_dimension(params.max_dimension), modulus(params.modulus) {}
 
 	void set_complex(Complex* _complex) { complex = _complex; }
 

--- a/include/output/barcode_hdf5.h
+++ b/include/output/barcode_hdf5.h
@@ -6,6 +6,7 @@
 #include "../argparser.h"
 #include "../definitions.h"
 #include "../input/flagser.h"
+#include "../parameters.h"
 #include "hdf5_helper.h"
 
 #include <hdf5.h>
@@ -38,15 +39,14 @@ template <typename Complex> class barcode_hdf5_output_t : public output_t<Comple
 	static size_t total_top_dimension;
 
 public:
-	barcode_hdf5_output_t(const named_arguments_t& named_arguments)
-	    : min_dimension(atoi(get_argument_or_default(named_arguments, "min-dim", "0"))),
-	      max_dimension(atoi(get_argument_or_default(named_arguments, "max-dim", "65535"))),
-	      modulus(atoi(get_argument_or_default(named_arguments, "modulus", "2"))),
-	      approximate_computation(argument_was_passed(named_arguments, "approximate")),
-	      aggregate_results(argument_was_passed(named_arguments, "components")),
-	      output_bars(argument_was_passed(named_arguments, "filtration")) {
-		const auto ids =
-		    open_or_create_group(get_argument_or_fail(named_arguments, "out", "Please provide an output file."));
+	barcode_hdf5_output_t(const flagser_parameters& params)
+	    : min_dimension(params.min_dimension), max_dimension(params.max_dimension), modulus(params.modulus),
+	      approximate_computation(params.approximate_computation),
+	      aggregate_results(!params.split_into_connected_components),
+	      /** FIXME: If we pass zero filtration, should output_bars be true ?
+	       */
+	      output_bars(params.filtration_algorithm.get() != nullptr) {
+		const auto ids = open_or_create_group(params.output_name);
 		file_id = ids.first;
 		group_id = ids.second;
 		barcode_buffer.reserve(BUFFER_SIZE + 50);

--- a/include/output/barcode_hdf5.h
+++ b/include/output/barcode_hdf5.h
@@ -43,8 +43,6 @@ public:
 	    : min_dimension(params.min_dimension), max_dimension(params.max_dimension), modulus(params.modulus),
 	      approximate_computation(params.approximate_computation),
 	      aggregate_results(!params.split_into_connected_components),
-	      /** FIXME: If we pass zero filtration, should output_bars be true ?
-	       */
 	      output_bars(params.filtration_algorithm.get() != nullptr) {
 		const auto ids = open_or_create_group(params.output_name);
 		file_id = ids.first;

--- a/include/output/base.h
+++ b/include/output/base.h
@@ -3,7 +3,6 @@
 #include <fstream>
 #include <string>
 
-#include "../argparser.h"
 #include "../definitions.h"
 
 template <typename Complex> class output_t {
@@ -27,9 +26,7 @@ protected:
 	std::ofstream outstream;
 
 public:
-	file_output_t(const named_arguments_t& named_arguments) {
-		auto filename =
-		    get_argument_or_fail(named_arguments, "out", "Please provide an output filename via \"--out filename\" .");
+	file_output_t(const std::string filename) {
 
 		std::ifstream f(filename);
 		if (f.good()) {

--- a/include/output/betti.h
+++ b/include/output/betti.h
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include "../definitions.h"
+#include "../parameters.h"
 #include "base.h"
 
 template <typename Complex> class betti_output_t : public file_output_t<Complex> {
@@ -24,13 +25,11 @@ template <typename Complex> class betti_output_t : public file_output_t<Complex>
 	static size_t total_top_dimension;
 
 public:
-	betti_output_t(const named_arguments_t& named_arguments)
-	    : file_output_t<Complex>(named_arguments),
-	      min_dimension(atoi(get_argument_or_default(named_arguments, "min-dim", "0"))),
-	      max_dimension(atoi(get_argument_or_default(named_arguments, "max-dim", "65535"))),
-	      modulus(atoi(get_argument_or_default(named_arguments, "modulus", "2"))),
-	      approximate_computation(argument_was_passed(named_arguments, "approximate")),
-	      aggregate_results(argument_was_passed(named_arguments, "components")) {}
+	betti_output_t(const flagser_parameters& params)
+	    : file_output_t<Complex>(params.output_name), min_dimension(params.min_dimension),
+	      max_dimension(params.max_dimension), modulus(params.modulus),
+	      approximate_computation(params.approximate_computation),
+	      aggregate_results(!params.split_into_connected_components) {}
 
 	virtual void finished(bool with_cell_counts = true) override;
 	virtual void set_complex(Complex* _complex) override { complex = _complex; }

--- a/include/output/hdf5.h
+++ b/include/output/hdf5.h
@@ -6,6 +6,7 @@
 #include "../argparser.h"
 #include "../definitions.h"
 #include "../input/flagser.h"
+#include "../parameters.h"
 #include "./hdf5_helper.h"
 
 #include <hdf5.h>
@@ -20,9 +21,8 @@ class hdf5_output_t {
 	std::vector<std::vector<vertex_index_t>> buffer;
 
 public:
-	hdf5_output_t(const named_arguments_t& named_arguments) {
-		auto ids = open_or_create_group(
-		    get_argument_or_fail(named_arguments, "out", "Please provide an output file for the list of cells."));
+	hdf5_output_t(const flagser_parameters& params) {
+		auto ids = open_or_create_group(params.output_name);
 		file_id = ids.first;
 		group_id = ids.second;
 	}

--- a/include/output/output_classes.h
+++ b/include/output/output_classes.h
@@ -28,31 +28,21 @@ template <typename T, typename... Args> std::unique_ptr<T> make_unique(Args&&...
 }
 #endif
 
-bool has_zero_filtration_and_no_explicit_output(const named_arguments_t& named_arguments) {
-	return strlen(get_argument_or_default(named_arguments, "out-format", "")) == 0 &&
-	       std::string(get_argument_or_default(named_arguments, "filtration", "zero")) == "zero";
-}
-
-template <typename Complex> std::unique_ptr<output_t<Complex>> get_output(const named_arguments_t& named_arguments) {
+template <typename Complex> std::unique_ptr<output_t<Complex>> get_output(const flagser_parameters& params) {
 	// using std namespace because of std::make_unique workaround
 	// This restrict the scope to inside the function
 	using namespace std;
 
-	std::string output_name = "barcode";
-	auto it = named_arguments.find("out-format");
-	if (it != named_arguments.end()) { output_name = it->second; }
+	if (params.output_format == "betti") return make_unique<betti_output_t<Complex>>(params);
+	if (params.output_format == "barcode") return make_unique<barcode_output_t<Complex>>(params);
 
-	if (output_name == "betti" || has_zero_filtration_and_no_explicit_output(named_arguments))
-		return make_unique<betti_output_t<Complex>>(named_arguments);
-	if (output_name == "barcode") return make_unique<barcode_output_t<Complex>>(named_arguments);
-
-	if (output_name == "none") return make_unique<trivial_output_t<Complex>>(named_arguments);
+	if (params.output_format == "none") return make_unique<trivial_output_t<Complex>>(params);
 
 #ifdef WITH_HDF5
-	if (output_name == "barcode:hdf5") return make_unique<barcode_hdf5_output_t<Complex>>(named_arguments);
+	if (params.output_format == "barcode:hdf5") return make_unique<barcode_hdf5_output_t<Complex>>(params);
 #endif
 
-	std::cerr << "The output format \"" << output_name << "\" could not be found." << std::endl;
+	std::cerr << "The output format \"" << params.output_format << "\" could not be found." << std::endl;
 	exit(1);
 }
 

--- a/include/output/trivial.h
+++ b/include/output/trivial.h
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include "../definitions.h"
+#include "../parameters.h"
 #include "base.h"
 
 template <typename Complex> class trivial_output_t : public output_t<Complex> {
@@ -24,12 +25,10 @@ template <typename Complex> class trivial_output_t : public output_t<Complex> {
 	static size_t total_top_dimension;
 
 public:
-	trivial_output_t(const named_arguments_t& named_arguments)
-	    : min_dimension(atoi(get_argument_or_default(named_arguments, "min-dim", "0"))),
-	      max_dimension(atoi(get_argument_or_default(named_arguments, "max-dim", "65535"))),
-	      modulus(atoi(get_argument_or_default(named_arguments, "modulus", "2"))),
-	      approximate_computation(argument_was_passed(named_arguments, "approximate")),
-	      aggregate_results(argument_was_passed(named_arguments, "components")) {}
+	trivial_output_t(const flagser_parameters& params)
+	    : min_dimension(params.min_dimension), max_dimension(params.max_dimension), modulus(params.modulus),
+	      approximate_computation(params.approximate_computation),
+	      aggregate_results(!params.split_into_connected_components) {}
 
 	virtual void finished(bool with_cell_counts = true) override;
 	virtual void set_complex(Complex* _complex) override { complex = _complex; }

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -10,6 +10,9 @@
 /* Avoid name collision with generic name parameters*/
 class flagser_parameters {
 public:
+    flagser_parameters() {
+        filtration_algorithm.reset(get_filtration_computer("zero"));
+    }
 	flagser_parameters(const named_arguments_t& named_arguments) {
 		named_arguments_t::const_iterator it;
 

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -16,6 +16,8 @@ public:
 		output_name =
 		    get_argument_or_fail(named_arguments, "out", "Please provide an output filename via \"--out filename\" .");
 
+		if ((it = named_arguments.find("in-format")) != named_arguments.end()) { input_format = it->second; }
+
 		if ((it = named_arguments.find("out-format")) != named_arguments.end()) { output_format = it->second; }
 
 		if ((it = named_arguments.find("approximate")) != named_arguments.end()) {
@@ -48,9 +50,11 @@ public:
 	bool directed = false;
 	bool approximate_computation = false;
 	size_t max_entries = std::numeric_limits<size_t>::max();
+	std::string input_format = "flagser";
 	std::string output_name = "";
 	std::string output_format = "barcode";
 	std::string cache = "";
+	std::string hdf5_type = "";
 	std::unique_ptr<filtration_algorithm_t> filtration_algorithm;
 
 private:

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -1,0 +1,64 @@
+#ifndef PARAMETERS_H
+#define PARAMETERS_H
+
+#include "argparser.h"
+#include "definitions.h"
+#include "filtration_algorithms.h"
+
+#include <cstring>
+
+/* Avoid name collision with generic name parameters*/
+class flagser_parameters {
+public:
+	flagser_parameters(const named_arguments_t& named_arguments) {
+		named_arguments_t::const_iterator it;
+
+		output_name =
+		    get_argument_or_fail(named_arguments, "out", "Please provide an output filename via \"--out filename\" .");
+
+		if ((it = named_arguments.find("out-format")) != named_arguments.end()) { output_format = it->second; }
+
+		if ((it = named_arguments.find("approximate")) != named_arguments.end()) {
+			max_entries = atoi(it->second);
+			approximate_computation = true;
+		}
+
+		directed = std::string(get_argument_or_default(named_arguments, "undirected", "directed")) != "true";
+
+		split_into_connected_components = named_arguments.find("components") != named_arguments.end();
+
+		if ((it = named_arguments.find("max-dim")) != named_arguments.end()) { max_dimension = atoi(it->second); }
+
+		if ((it = named_arguments.find("min-dim")) != named_arguments.end()) { min_dimension = atoi(it->second); }
+
+		if (has_zero_filtration_and_no_explicit_output(named_arguments)) { output_format = "betti"; }
+
+		filtration_algorithm.reset(
+		    get_filtration_computer(get_argument_or_default(named_arguments, "filtration", "zero")));
+
+#ifdef USE_COEFFICIENTS
+		if ((it = named_arguments.find("modulus")) != named_arguments.end()) { modulus = atoi(it->second); }
+#endif
+	}
+
+	unsigned short max_dimension = std::numeric_limits<unsigned short>::max();
+	unsigned short min_dimension = 0;
+	coefficient_t modulus = 2;
+	bool split_into_connected_components = false;
+	bool directed = false;
+	bool approximate_computation = false;
+	size_t max_entries = std::numeric_limits<size_t>::max();
+	std::string output_name = "";
+	std::string output_format = "barcode";
+	std::string cache = "";
+	std::unique_ptr<filtration_algorithm_t> filtration_algorithm;
+
+private:
+	/* data */
+	bool has_zero_filtration_and_no_explicit_output(const named_arguments_t& named_arguments) {
+		return strlen(get_argument_or_default(named_arguments, "out-format", "")) == 0 &&
+		       std::string(get_argument_or_default(named_arguments, "filtration", "zero")) == "zero";
+	}
+};
+
+#endif /* ifndef PARAMETERS_H */

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -41,6 +41,11 @@ public:
 		filtration_algorithm.reset(
 		    get_filtration_computer(get_argument_or_default(named_arguments, "filtration", "zero")));
 
+        if ((it = named_arguments.find("threshold")) != named_arguments.end()) {
+            std::string parameter = std::string(it->second);
+            threshold = std::stof(parameter, nullptr);
+        }
+
 #ifdef USE_COEFFICIENTS
 		if ((it = named_arguments.find("modulus")) != named_arguments.end()) { modulus = atoi(it->second); }
 #endif
@@ -49,6 +54,7 @@ public:
 	unsigned short max_dimension = std::numeric_limits<unsigned short>::max();
 	unsigned short min_dimension = 0;
 	coefficient_t modulus = 2;
+	value_t threshold = std::numeric_limits<value_t>::max();
 	bool split_into_connected_components = false;
 	bool directed = false;
 	bool approximate_computation = false;

--- a/src/flagser-count.cpp
+++ b/src/flagser-count.cpp
@@ -168,7 +168,7 @@ int main(int argc, char** argv) {
 	if (positional_arguments.size() == 0) { print_usage_and_exit(-1); }
 	const char* input_filename = positional_arguments[0];
 
-	filtered_directed_graph_t graph = read_filtered_directed_graph(input_filename, named_arguments);
+	filtered_directed_graph_t graph = read_filtered_directed_graph(input_filename, params);
 
 	auto cell_count = count_cells(graph, params);
 }

--- a/src/flagser-count.cpp
+++ b/src/flagser-count.cpp
@@ -14,6 +14,7 @@
 // #define MANY_VERTICES
 
 #include "../include/argparser.h"
+#include "../include/parameters.h"
 #include "../include/persistence.h"
 
 #ifdef WITH_HDF5
@@ -32,7 +33,7 @@
 
 #include "../include/usage/flagser-count.h"
 
-std::vector<size_t> count_cells(filtered_directed_graph_t& graph, const named_arguments_t& named_arguments) {
+std::vector<size_t> count_cells(filtered_directed_graph_t& graph, const flagser_parameters& params) {
 	// Aggregated counts
 	std::vector<size_t> total_cell_count;
 
@@ -41,12 +42,11 @@ std::vector<size_t> count_cells(filtered_directed_graph_t& graph, const named_ar
 
 #ifdef WITH_HDF5
 	hdf5_output_t* output = nullptr;
-	if (argument_was_passed(named_arguments, "out")) { output = new hdf5_output_t(named_arguments); }
+	output = new hdf5_output_t(params);
 #endif
 
-	bool split_into_connected_components = named_arguments.find("components") != named_arguments.end();
 	std::vector<filtered_directed_graph_t> subgraphs{graph};
-	if (split_into_connected_components) { subgraphs = graph.get_connected_subgraphs(2); }
+	if (params.split_into_connected_components) { subgraphs = graph.get_connected_subgraphs(2); }
 
 	bool is_first_line = true;
 	for (auto subgraph : subgraphs) {
@@ -99,7 +99,7 @@ std::vector<size_t> count_cells(filtered_directed_graph_t& graph, const named_ar
 #ifdef WITH_HDF5
 			    output
 #endif
-			    );
+			);
 
 #ifdef WITH_HDF5
 		if (output != nullptr)
@@ -146,14 +146,14 @@ std::vector<size_t> count_cells(filtered_directed_graph_t& graph, const named_ar
 	if (output != nullptr) delete output;
 #endif
 
-	if (split_into_connected_components) {
+	if (params.split_into_connected_components) {
 		std::cout << std::endl << "# Total" << std::endl;
 		std::cout << total_euler_characteristic;
 		for (size_t dim = 0; dim < total_max_dim; dim++) std::cout << " " << total_cell_count[dim];
 		std::cout << std::endl;
 	}
 
-        return total_cell_count;
+	return total_cell_count;
 }
 
 int main(int argc, char** argv) {
@@ -161,6 +161,7 @@ int main(int argc, char** argv) {
 
 	auto positional_arguments = get_positional_arguments(arguments);
 	auto named_arguments = get_named_arguments(arguments);
+	auto params = flagser_parameters(named_arguments);
 	named_arguments_t::const_iterator it;
 	if (named_arguments.find("help") != named_arguments.end()) { print_usage_and_exit(-1); }
 
@@ -169,5 +170,5 @@ int main(int argc, char** argv) {
 
 	filtered_directed_graph_t graph = read_filtered_directed_graph(input_filename, named_arguments);
 
-	auto cell_count = count_cells(graph, named_arguments);
+	auto cell_count = count_cells(graph, params);
 }

--- a/src/flagser.cpp
+++ b/src/flagser.cpp
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
 	if (positional_arguments.size() == 0) { print_usage_and_exit(-1); }
 	const char* input_filename = positional_arguments[0];
 
-	filtered_directed_graph_t graph = read_filtered_directed_graph(input_filename, named_arguments);
+	filtered_directed_graph_t graph = read_filtered_directed_graph(input_filename, params);
 
 	compute_homology(graph, params);
 }

--- a/src/flagser.cpp
+++ b/src/flagser.cpp
@@ -12,7 +12,7 @@
 // #define USE_COEFFICIENTS
 // #define MANY_VERTICES
 
-#include "../include/argparser.h"
+#include "../include/parameters.h"
 #include "../include/persistence.h"
 
 //
@@ -38,31 +38,22 @@ std::vector<persistence_computer_t<directed_flag_complex_compute_t>>
 #else
 void
 #endif
-compute_homology(filtered_directed_graph_t& graph, const named_arguments_t& named_arguments, size_t max_entries,
-                 coefficient_t modulus) {
-
-	unsigned short max_dimension = std::numeric_limits<unsigned short>::max();
-	unsigned short min_dimension = 0;
-	bool split_into_connected_components = named_arguments.find("components") != named_arguments.end();
-
-	named_arguments_t::const_iterator it;
-	if ((it = named_arguments.find("max-dim")) != named_arguments.end()) { max_dimension = atoi(it->second); }
-	if ((it = named_arguments.find("min-dim")) != named_arguments.end()) { min_dimension = atoi(it->second); }
+compute_homology(filtered_directed_graph_t& graph, const flagser_parameters& params) {
 
 	std::vector<filtered_directed_graph_t> subgraphs{graph};
-	if (split_into_connected_components) { subgraphs = graph.get_connected_subgraphs(2); }
+	if (params.split_into_connected_components) { subgraphs = graph.get_connected_subgraphs(2); }
 
 #ifdef RETRIEVE_PERSISTENCE
 	std::vector<persistence_computer_t<directed_flag_complex_compute_t>> complex_subgraphs;
 #endif
 
-	auto output = get_output<directed_flag_complex_compute_t>(named_arguments);
+	auto output = get_output<directed_flag_complex_compute_t>(params);
 	size_t component_number = 1;
 	for (auto subgraph : subgraphs) {
-		directed_flag_complex_compute_t complex(subgraph, named_arguments);
+		directed_flag_complex_compute_t complex(subgraph, params);
 
 		output->set_complex(&complex);
-		if (split_into_connected_components) {
+		if (params.split_into_connected_components) {
 			if (component_number > 1) output->print("\n");
 			output->print("## Path component number ");
 			output->print(std::to_string(component_number));
@@ -79,15 +70,16 @@ compute_homology(filtered_directed_graph_t& graph, const named_arguments_t& name
 
 #ifdef RETRIEVE_PERSISTENCE
 		complex_subgraphs.push_back(
-		    persistence_computer_t<decltype(complex)>(complex, output.get(), max_entries, modulus));
-		complex_subgraphs.back().compute_persistence(min_dimension, max_dimension);
+		    persistence_computer_t<decltype(complex)>(complex, output.get(), params.max_entries, params.modulus));
+		complex_subgraphs.back().compute_persistence(params.min_dimension, params.max_dimension);
 #else
-		persistence_computer_t<decltype(complex)> persistence_computer(complex, output.get(), max_entries, modulus);
-		persistence_computer.compute_persistence(min_dimension, max_dimension);
+		persistence_computer_t<decltype(complex)> persistence_computer(complex, output.get(), params.max_entries,
+		                                                               params.modulus);
+		persistence_computer.compute_persistence(params.min_dimension, params.max_dimension);
 #endif
 	}
 
-	if (split_into_connected_components) { output->print("\n## Total\n"); }
+	if (params.split_into_connected_components) { output->print("\n## Total\n"); }
 
 	output->print_aggregated_results();
 
@@ -101,6 +93,8 @@ int main(int argc, char** argv) {
 
 	auto positional_arguments = get_positional_arguments(arguments);
 	auto named_arguments = get_named_arguments(arguments);
+	auto params = flagser_parameters(named_arguments);
+
 	if (named_arguments.find("help") != named_arguments.end()) { print_usage_and_exit(-1); }
 
 	if (positional_arguments.size() == 0) { print_usage_and_exit(-1); }
@@ -108,13 +102,5 @@ int main(int argc, char** argv) {
 
 	filtered_directed_graph_t graph = read_filtered_directed_graph(input_filename, named_arguments);
 
-	size_t max_entries = std::numeric_limits<size_t>::max();
-	coefficient_t modulus = 2;
-	named_arguments_t::const_iterator it;
-	if ((it = named_arguments.find("approximate")) != named_arguments.end()) { max_entries = atoi(it->second); }
-#ifdef USE_COEFFICIENTS
-	if ((it = named_arguments.find("modulus")) != named_arguments.end()) { modulus = atoi(it->second); }
-#endif
-
-	compute_homology(graph, named_arguments, max_entries, modulus);
+	compute_homology(graph, params);
 }

--- a/src/ripser.cpp
+++ b/src/ripser.cpp
@@ -509,6 +509,7 @@ int main(int argc, char** argv) {
 	auto arguments = parse_arguments(argc, argv);
 	auto positional_arguments = get_positional_arguments(arguments);
 	auto named_arguments = get_named_arguments(arguments);
+	auto params = flagser_parameters(named_arguments);
 
 	if (named_arguments.find("help") != named_arguments.end()) { print_usage_and_exit(-1); }
 	if (positional_arguments.size() == 0) print_usage_and_exit(-1);
@@ -531,31 +532,15 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	if ((it = named_arguments.find("max-dim")) != named_arguments.end()) {
-		std::string parameter = std::string(it->second);
-		size_t next_pos;
-		dim_max = std::stol(parameter, &next_pos);
-		if (next_pos != parameter.size()) print_usage_and_exit(-1);
-	}
-
-	if ((it = named_arguments.find("threshold")) != named_arguments.end()) {
-		std::string parameter = std::string(it->second);
-		size_t next_pos;
-		threshold = std::stof(parameter, &next_pos);
-		if (next_pos != parameter.size()) print_usage_and_exit(-1);
-	}
+	dim_max = params.max_dimension;
+	threshold = params.threshold;
 
 #ifdef USE_COEFFICIENTS
-	if ((it = named_arguments.find("modulus")) != named_arguments.end()) {
-		std::string parameter = std::string(it->second);
-		size_t next_pos;
-		modulus = std::stol(parameter, &next_pos);
-		if (next_pos != parameter.size() || !is_prime(modulus)) print_usage_and_exit(-1);
-	}
+	modulus = params.modulus;
 #endif
 
 	size_t max_entries = std::numeric_limits<size_t>::max();
-	if ((it = named_arguments.find("approximate")) != named_arguments.end()) { max_entries = atoi(it->second); }
+	max_entries = params.max_entries;
 
 	std::ifstream file_stream(positional_arguments[0]);
 	if (positional_arguments[0] && file_stream.fail()) {
@@ -575,7 +560,7 @@ int main(int argc, char** argv) {
 	dim_max = std::min(dim_max, n - 2);
 
 	vietoris_rips_complex_t<decltype(dist)> vietoris_rips_complex(dist, dim_max, modulus);
-	auto output = get_output<decltype(vietoris_rips_complex)>(named_arguments);
+	auto output = get_output<decltype(vietoris_rips_complex)>(params);
 	output->set_complex(&vietoris_rips_complex);
 
 	persistence_computer_t<decltype(vietoris_rips_complex)> persistence_computer(vietoris_rips_complex, output.get(),

--- a/test/base.h
+++ b/test/base.h
@@ -1,101 +1,104 @@
-#include <stdexcept>
-#include <cstdio>
-#include "../include/persistence.h"
 #include "../include/complex/directed_flag_complex_computer.h"
 #include "../include/input/input_classes.h"
 #include "../include/output/output_classes.h"
+#include "../include/parameters.h"
+#include "../include/persistence.h"
+#include <cstdio>
+#include <stdexcept>
 
 void compute(std::string&& filename, std::vector<size_t> homology, std::string out_filename = "") {
-  std::cout << "Testing " << filename << "..." << std::endl;
-  std::unordered_map<std::string, const char*> named_arguments;
-  const std::string out_format = out_filename.size() == 0 ? "none" : "barcode";
-  named_arguments.insert(std::pair<std::string, const char*>("out-format", out_format.c_str()));
-  if (out_filename.size() > 0) {
-    named_arguments.insert(std::pair<std::string, const char*>("out", out_filename.c_str()));
-  }
-	filtered_directed_graph_t graph = read_filtered_directed_graph(filename.c_str(), named_arguments);
+	std::cout << "Testing " << filename << "..." << std::endl;
+	flagser_parameters params;
+	params.output_format = out_filename.size() == 0 ? "none" : "barcode";
+	if (out_filename.size() > 0) { params.output_name = out_filename; }
+    params.directed = true;
+	filtered_directed_graph_t graph = read_filtered_directed_graph(filename.c_str(), params);
 
 	size_t max_entries = std::numeric_limits<size_t>::max();
 	coefficient_t modulus = 2;
 
-  unsigned short max_dimension = std::numeric_limits<unsigned short>::max();
+	unsigned short max_dimension = std::numeric_limits<unsigned short>::max();
 	unsigned short min_dimension = 0;
 
-	auto output = get_output<directed_flag_complex_computer_t>(named_arguments);
-  directed_flag_complex_computer_t complex(graph, named_arguments);
+	auto output = get_output<directed_flag_complex_computer_t>(params);
+	directed_flag_complex_computer_t complex(graph, params);
 
-  output->set_complex(&complex);
+	output->set_complex(&complex);
 
-  auto result = persistence_computer_t<decltype(complex)>(complex, output.get(), max_entries, modulus);
-  result.compute_persistence(min_dimension, max_dimension);
+	auto result = persistence_computer_t<decltype(complex)>(complex, output.get(), max_entries, modulus);
+	result.compute_persistence(min_dimension, max_dimension);
 
-  bool correct = true;
+	bool correct = true;
 
-  if (result.get_betti_numbers().size() != homology.size()) {
-    correct = false;
-  } else {
-    for (auto i = 0ul; i < homology.size(); i++) {
-      if (result.get_betti_numbers()[i] != homology[i]) {
-        correct = false;
-        break;
-      }
-    }
-  }
+	if (result.get_betti_numbers().size() != homology.size()) {
+		correct = false;
+	} else {
+		for (auto i = 0ul; i < homology.size(); i++) {
+			if (result.get_betti_numbers()[i] != homology[i]) {
+				correct = false;
+				break;
+			}
+		}
+	}
 
-  if (!correct) {
-    std::cout << "Expected betti numbers: ";
-    for (auto b : homology) std::cout << std::to_string(b) << " ";
-    std::cout << "; computed: ";
-    for (auto b : result.get_betti_numbers()) std::cout << std::to_string(b) << " ";
-    std::cout << std::endl;
-    std::cout << "FAILED" << std::endl;
-  //   throw std::logic_error(std::string("Wrong betti numbers computed."));
-  }
+	if (!correct) {
+		std::cout << "Expected betti numbers: ";
+		for (auto b : homology) std::cout << std::to_string(b) << " ";
+		std::cout << "; computed: ";
+		for (auto b : result.get_betti_numbers()) std::cout << std::to_string(b) << " ";
+		std::cout << std::endl;
+		std::cout << "FAILED" << std::endl;
+		//   throw std::logic_error(std::string("Wrong betti numbers computed."));
+	}
 
-  std::cout << "All good." << std::endl;
+	std::cout << "All good." << std::endl;
 }
 
-void run_all(bool full=false) {
-  compute("../../test/d2.flag", {{1ul, 1ul}});
-  compute("../../test/a.flag", {{1ul, 2ul, 0ul}});
-  compute("../../test/b.flag", {{1ul, 0ul, 0ul}});
-  compute("../../test/c.flag", {{1ul, 5ul}});
-  compute("../../test/d.flag", {{1ul, 0ul, 1ul}});
-  compute("../../test/e.flag", {{1ul, 0ul, 0ul, 0ul}});
-  compute("../../test/f.flag", {{1ul, 0ul, 0ul}});
-  compute("../../test/d3.flag", {{1ul, 0ul, 2ul}});
-  compute("../../test/d3-allzero.flag", {{1ul, 0ul, 2ul}});
-  compute("../../test/double-d3.flag", {{1, 0, 5}});
-  compute("../../test/double-d3-allzero.flag", {{1, 0, 5}});
-  compute("../../test/d4.flag", {{1, 0, 0, 9}});
-  compute("../../test/d4-allzero.flag", {{1, 0, 0, 9}});
-  compute("../../test/d5.flag", {{1, 0, 0, 0, 44}});
-  compute("../../test/d7.flag", {{1, 0, 0, 0, 0, 0, 1854}});
+void run_all(bool full = false) {
+	compute("../../test/d2.flag", {{1ul, 1ul}});
+	compute("../../test/a.flag", {{1ul, 2ul, 0ul}});
+	compute("../../test/b.flag", {{1ul, 0ul, 0ul}});
+	compute("../../test/c.flag", {{1ul, 5ul}});
+	compute("../../test/d.flag", {{1ul, 0ul, 1ul}});
+	compute("../../test/e.flag", {{1ul, 0ul, 0ul, 0ul}});
+	compute("../../test/f.flag", {{1ul, 0ul, 0ul}});
+	compute("../../test/d3.flag", {{1ul, 0ul, 2ul}});
+	compute("../../test/d3-allzero.flag", {{1ul, 0ul, 2ul}});
+	compute("../../test/double-d3.flag", {{1, 0, 5}});
+	compute("../../test/double-d3-allzero.flag", {{1, 0, 5}});
+	compute("../../test/d4.flag", {{1, 0, 0, 9}});
+	compute("../../test/d4-allzero.flag", {{1, 0, 0, 9}});
+	compute("../../test/d5.flag", {{1, 0, 0, 0, 44}});
+	compute("../../test/d7.flag", {{1, 0, 0, 0, 0, 0, 1854}});
 
-  if (full) {
-    const auto file_path = "../flagser_tmp";
-    std::remove(file_path);
-    compute("../../test/a.flag", {{1ul, 2ul, 0ul}}, file_path);
-    // Check that the file has the right content
-    std::ifstream t(file_path);
-    std::string file_content((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
-    std::remove(file_path);
+	if (full) {
+		const auto file_path = "../flagser_tmp";
+		std::remove(file_path);
+		compute("../../test/a.flag", {{1ul, 2ul, 0ul}}, file_path);
+		// Check that the file has the right content
+		std::ifstream t(file_path);
+		std::string file_content((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
+		std::remove(file_path);
 
-    std::string expected_file_content = "# persistence intervals in dimension 0\n [0, )\n# persistence intervals in dimension 1\n [0, )\n [0, )\n# persistence intervals in dimension 2\n\nThe remaining homology groups are trivial.\n\n# Euler characteristic: -1\n\n# Betti numbers:\n#\t\tdim H_0 = 1\n#\t\tdim H_1 = 2\n#\t\tdim H_2 = 0\n\n# Cell counts:\n#\t\tdim C_0 = 5\n#\t\tdim C_1 = 7\n#\t\tdim C_2 = 1\n#\t\tdim C_3 = 0\n";
+		std::string expected_file_content =
+		    "# persistence intervals in dimension 0\n [0, )\n# persistence intervals in dimension 1\n [0, )\n [0, )\n# "
+		    "persistence intervals in dimension 2\n\nThe remaining homology groups are trivial.\n\n# Euler "
+		    "characteristic: -1\n\n# Betti numbers:\n#\t\tdim H_0 = 1\n#\t\tdim H_1 = 2\n#\t\tdim H_2 = 0\n\n# Cell "
+		    "counts:\n#\t\tdim C_0 = 5\n#\t\tdim C_1 = 7\n#\t\tdim C_2 = 1\n#\t\tdim C_3 = 0\n";
 
-    if (file_content != expected_file_content) {
-      std::cerr << "The file content differed!" << std::endl;
-      std::cerr << std::endl << "*** EXPECTED ***" << std::endl << expected_file_content << std::endl;
-      std::cerr << std::endl << "*** GOT ***" << std::endl << file_content << std::endl;
-      throw std::logic_error("The file content differed.");
-    }
+		if (file_content != expected_file_content) {
+			std::cerr << "The file content differed!" << std::endl;
+			std::cerr << std::endl << "*** EXPECTED ***" << std::endl << expected_file_content << std::endl;
+			std::cerr << std::endl << "*** GOT ***" << std::endl << file_content << std::endl;
+			throw std::logic_error("The file content differed.");
+		}
 
 #ifdef NDEBUG
-    std::cout << "Running extensive tests, this might take a while." << std::endl;
-    compute("../../test/medium-test-data.flag", {{14237, 39477, 378, 0}});
-    compute("../../test/d10.flag", {{1, 0, 0, 0, 0, 0, 0, 0, 0, 1334961}});
+		std::cout << "Running extensive tests, this might take a while." << std::endl;
+		compute("../../test/medium-test-data.flag", {{14237, 39477, 378, 0}});
+		compute("../../test/d10.flag", {{1, 0, 0, 0, 0, 0, 0, 0, 0, 1334961}});
 #else
-    std::cout << "Skipping extensive tests." << std::endl;
+		std::cout << "Skipping extensive tests." << std::endl;
 #endif
-  }
+	}
 }


### PR DESCRIPTION
#29 manage input arguments with a centralized class.

This PR is a first draft that will allow to manage all the different input parameters directly into a single class.

This class takes the output from `get_named_arguments(arguments)` and parse each possible argument into it's corresponding attribute.

There are some places in the code where I added a "FIXME" which requires an input from the reviewer.

I think I did the best I could to update all the code to only use this new class, but I think that some improvement could be made in different classes:

* All classes that store `min_dimension`, `max_dimension`, `filtration`, etc. could store a reference to the `flagser_arguments` and then from the code call this reference.
* I don't know if argpaser should be the way to continue, or could we almost remove it and use something more standard to manage CL arguments (like GNU getopt, or any other fancy library that I don't know about)

I encountered an issue that I couldn't resolve directly. I added `#include "../parameters.h"` directly in `output/base.h` instead of adding it into each output class. But I encountered a hell of include recursively that I couldn't resolve ... If you can give it a try, it could be fun :)