### PR TITLE
Support threads and exceptions

### DIFF
--- a/include/algorithms.h
+++ b/include/algorithms.h
@@ -111,11 +111,7 @@ struct remove_edges_filtration : public filtration_algorithm_t {
 
 		if (dimension == 0) { return (0.0f); }
 
-		if (dimension == 1) {
-
-			std::cerr << "Please provide a graph with random weights on the edges." << std::endl;
-			exit(-1);
-		}
+		if (dimension == 1) { throw std::runtime_error("Please provide a graph with random weights on the edges."); }
 		return (max(boundary_filtration, 0, dimension));
 	}
 };

--- a/include/argparser.h
+++ b/include/argparser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -22,8 +23,7 @@ const char* get_argument_or_fail(const named_arguments_t& args, const std::strin
 	auto it = args.find(name);
 	if (it != args.end()) return it->second;
 
-	std::cerr << msg << std::endl;
-	exit(-1);
+	throw std::invalid_argument(msg.c_str());
 }
 
 bool argument_was_passed(const named_arguments_t& args, const std::string name) {

--- a/include/complex/directed_flag_complex_computer.h
+++ b/include/complex/directed_flag_complex_computer.h
@@ -99,8 +99,7 @@ struct compute_filtration_t {
 						err += " of ";
 						err += cell.to_string(size - 1);
 						err += ".\n";
-						std::cerr << err;
-						exit(-1);
+						throw std::runtime_error(err);
 					}
 					boundary_filtration[i] = current_filtration[pair->second + cell_hash_offsets[thread_index]];
 				}
@@ -375,8 +374,7 @@ struct store_coboundaries_in_cache_t {
 						std::string err = "Could not find coboundary ";
 						err += cb.to_string(current_dimension + 1);
 						err += ".\n";
-						std::cerr << err;
-						exit(-1);
+						throw std::runtime_error(err);
 					}
 					coboundary_matrix.push_back(
 					    make_entry(index_t(pair->second + cell_hash_offsets[thread_index]), i & 1 ? -1 + modulus : 1));
@@ -422,8 +420,8 @@ void directed_flag_complex_computer_t::prepare_next_dimension(int dimension) {
 	if (cache != "") {
 #ifdef USE_COEFFICIENTS
 		// TODO: Make this work
-		std::cerr << "Sorry, caching does not work with coefficients yet." << std::endl;
-		exit(1);
+		std::string err_msg = "Sorry, caching does not work with coefficients yet.";
+		throw std::logic_error(err_msg);
 #endif
 		bool loaded_from_file = false;
 		for (size_t i = 0; i < nb_threads; i++) {

--- a/include/complex/directed_flag_complex_in_memory.h
+++ b/include/complex/directed_flag_complex_in_memory.h
@@ -49,15 +49,13 @@ public:
 		}
 
 		if (children == nullptr) {
-			std::cerr << "A cell could not be found in the directed flag complex." << std::endl;
-			exit(-1);
+			throw std::runtime_error("A cell could not be found in the directed flag complex.");
 		}
 
 		offset++;
 		auto pair = children->find(vertices[offset]);
 		if (pair == children->end()) {
-			std::cerr << "A cell could not be found in the directed flag complex." << std::endl;
-			exit(-1);
+			throw std::runtime_error("A cell could not be found in the directed flag complex.");
 		}
 
 		pair->second.set_data(dimension - 1, vertices, _data, offset);
@@ -67,15 +65,13 @@ public:
 		if (dimension == 0) return data;
 
 		if (children == nullptr) {
-			std::cerr << "A cell could not be found in the directed flag complex." << std::endl;
-			exit(-1);
+			throw std::runtime_error("A cell could not be found in the directed flag complex.");
 		}
 
 		offset++;
 		auto pair = children->find(vertices[offset]);
 		if (pair == children->end()) {
-			std::cerr << "A cell could not be found in the directed flag complex." << std::endl;
-			exit(-1);
+			throw std::runtime_error("A cell could not be found in the directed flag complex.");
 		}
 
 		return pair->second.get_data(dimension - 1, vertices, offset);

--- a/include/complex/directed_flag_complex_in_memory.h
+++ b/include/complex/directed_flag_complex_in_memory.h
@@ -23,8 +23,9 @@ public:
 	directed_flag_complex_cell_in_memory_t(vertex_index_t _vertex) : vertex(_vertex) {}
 
 	// TODO: Figure out how to do this in the destructor.
-	//       The problem was that the classes are copied around, so the destructor was called before
-	//       the actual destruction of the complex took place.
+	//       The problem was that the classes are copied around, so the
+	//       destructor was called before the actual destruction of the complex
+	//       took place.
 	void free_memory() {
 		if (children != nullptr) {
 			for (auto c : *children) c.second.free_memory();
@@ -109,8 +110,9 @@ private:
 template <typename ExtraData> class directed_flag_complex_in_memory_t {
 public:
 	std::vector<directed_flag_complex_cell_in_memory_t<ExtraData>> vertex_cells;
+	const size_t nb_threads;
 
-	directed_flag_complex_in_memory_t(const directed_graph_t& graph, int max_dimension = -1);
+	directed_flag_complex_in_memory_t(const directed_graph_t& graph, const size_t nb_threads, int max_dimension = -1);
 	~directed_flag_complex_in_memory_t() {
 		for (auto p : vertex_cells) p.free_memory();
 	}
@@ -130,13 +132,13 @@ public:
 
 	index_t euler_characteristic() {
 		std::vector<euler_characteristic_computer_t<ExtraData>> compute_euler_characteristic;
-		for (auto i = 0ul; i < PARALLEL_THREADS; i++)
+		for (auto i = 0ul; i < nb_threads; i++)
 			compute_euler_characteristic.push_back(euler_characteristic_computer_t<ExtraData>());
 
 		// TODO: Remove the 10000-hack
 		for_each_cell(compute_euler_characteristic, 0, 10000);
 		index_t euler_characteristic = 0;
-		for (auto i = 0ul; i < PARALLEL_THREADS; i++)
+		for (auto i = 0ul; i < nb_threads; i++)
 			euler_characteristic += compute_euler_characteristic[i]->euler_characteristic();
 
 		return euler_characteristic;
@@ -222,7 +224,9 @@ void construction_worker_thread(int number_of_threads, int thread_id,
 
 template <typename ExtraData>
 directed_flag_complex_in_memory_t<ExtraData>::directed_flag_complex_in_memory_t(const directed_graph_t& graph,
-                                                                                int max_dimension) {
+                                                                                const size_t nb_threads,
+                                                                                int max_dimension)
+    : nb_threads(nb_threads) {
 #ifdef INDICATE_PROGRESS
 	std::cout << "\033[K"
 	          << "constructing the directed flag complex" << std::flush << "\r";
@@ -234,16 +238,15 @@ directed_flag_complex_in_memory_t<ExtraData>::directed_flag_complex_in_memory_t(
 		vertex_cells.push_back(directed_flag_complex_cell_in_memory_t<ExtraData>(index));
 
 	// Now we start a few threads to construct the flag complex
-	std::vector<std::thread> t(PARALLEL_THREADS - 1);
+	std::vector<std::thread> t(nb_threads - 1);
 
-	for (auto index = 0ul; index < PARALLEL_THREADS - 1; ++index)
-		t[index] =
-		    std::thread(&construction_worker_thread<ExtraData>, PARALLEL_THREADS, index, this, &graph, max_dimension);
+	for (auto index = 0ul; index < nb_threads - 1; ++index)
+		t[index] = std::thread(&construction_worker_thread<ExtraData>, nb_threads, index, this, &graph, max_dimension);
 
 	// Also do work in this thread, namely the last bit
 	// For this last thread, take all the remaining vertices
-	construction_worker_thread(PARALLEL_THREADS, PARALLEL_THREADS - 1, this, &graph, max_dimension);
+	construction_worker_thread(nb_threads, nb_threads - 1, this, &graph, max_dimension);
 
 	// Wait until all threads stopped
-	for (auto i = 0ul; i < PARALLEL_THREADS - 1; ++i) t[i].join();
+	for (auto i = 0ul; i < nb_threads - 1; ++i) t[i].join();
 }

--- a/include/complex/directed_flag_complex_in_memory_computer.h
+++ b/include/complex/directed_flag_complex_in_memory_computer.h
@@ -101,7 +101,7 @@ private:
 
 template <typename Complex>
 void prepare_graph_filtration(Complex& complex, filtered_directed_graph_t& graph,
-                              filtration_algorithm_t* filtration_algorithm) {
+                              filtration_algorithm_t* filtration_algorithm, const size_t nb_threads) {
 	if (filtration_algorithm == nullptr) {
 		// All vertices get the trivial filtration value
 		graph.vertex_filtration = std::vector<value_t>(graph.vertex_filtration.size(), 0);
@@ -140,17 +140,17 @@ void prepare_graph_filtration(Complex& complex, filtered_directed_graph_t& graph
 	}
 
 	// Now reorder the edges
-	std::vector<vertex_index_t> new_edges[PARALLEL_THREADS];
-	std::vector<value_t> new_filtrations[PARALLEL_THREADS];
+	std::vector<std::vector<vertex_index_t>> new_edges(nb_threads);
+	std::vector<std::vector<value_t>> new_filtrations(nb_threads);
 	std::vector<reorder_edges_t> reorder_filtration;
-	for (int i = 0; i < PARALLEL_THREADS; i++)
+	for (size_t i = 0; i < nb_threads; i++)
 		reorder_filtration.push_back(reorder_edges_t(new_edges[i], new_filtrations[i],
 		                                             !computed_edge_filtration && filtration_algorithm != nullptr));
 	complex.for_each_cell(reorder_filtration, 1);
 
 	size_t current_filtration_index = 0;
 	size_t current_edge_index = 0;
-	for (int i = 0; i < PARALLEL_THREADS; i++) {
+	for (size_t i = 0; i < nb_threads; i++) {
 		for (auto e : new_edges[i]) graph.edges[current_edge_index++] = e;
 		if (!computed_edge_filtration && filtration_algorithm != nullptr)
 			for (auto f : new_filtrations[i]) graph.edge_filtration[current_filtration_index++] = f;
@@ -167,26 +167,28 @@ class directed_flag_complex_in_memory_computer_t {
 	int current_dimension = 0;
 	bool _is_top_dimension = false;
 	std::vector<size_t> cell_count;
+	const size_t nb_threads;
 
 	// Filtration
 	std::vector<value_t> next_filtration;
 
 	// Coboundaries
-	compressed_sparse_matrix<entry_t> coboundary_matrix[PARALLEL_THREADS];
-	size_t coboundary_matrix_offsets[PARALLEL_THREADS];
+	std::vector<compressed_sparse_matrix<entry_t>> coboundary_matrix;
+	std::vector<size_t> coboundary_matrix_offsets;
 	coefficient_t modulus;
 
 public:
 	directed_flag_complex_in_memory_computer_t(filtered_directed_graph_t& _graph, const flagser_parameters& params)
-	    : graph(_graph), flag_complex(graph), filtration_algorithm(params.filtration_algorithm.get()),
+	    : graph(_graph), flag_complex(graph, params.nb_threads), filtration_algorithm(params.filtration_algorithm.get()),
 	      min_dimension(params.min_dimension), max_dimension(params.max_dimension), cache(params.cache.c_str()),
+	      nb_threads(params.nb_threads), coboundary_matrix(nb_threads), coboundary_matrix_offsets(nb_threads, 0),
 	      modulus(params.modulus) {
 		cell_count.push_back(_graph.vertex_number());
 		cell_count.push_back(_graph.edge_number());
 
 		// Order the edges and compute the correct filtration
 		if (min_dimension <= 1 || (filtration_algorithm != nullptr && filtration_algorithm->needs_face_filtration()))
-			prepare_graph_filtration(flag_complex, graph, filtration_algorithm);
+			prepare_graph_filtration(flag_complex, graph, filtration_algorithm, nb_threads);
 	}
 
 	size_t number_of_cells(int dimension) const {
@@ -222,8 +224,8 @@ public:
 			    this, current_dimension, coboundary_matrix[0], -1, 1, modulus);
 		}
 
-		int i = 0;
-		while (i < PARALLEL_THREADS - 1 && index_t(coboundary_matrix_offsets[i + 1]) <= get_index(cell)) { i++; }
+		size_t i = 0;
+		while (i < nb_threads - 1 && index_t(coboundary_matrix_offsets[i + 1]) <= get_index(cell)) { i++; }
 		return coboundary_iterator_t<directed_flag_complex_in_memory_computer_t>(
 		    this, current_dimension, coboundary_matrix[i], index_t(get_index(cell) - coboundary_matrix_offsets[i]),
 		    get_coefficient(cell), modulus);
@@ -239,11 +241,11 @@ struct store_coboundaries_in_cache_t {
 	store_coboundaries_in_cache_t(compressed_sparse_matrix<entry_t>& _coboundary_matrix, int _current_dimension,
 	                              const filtered_directed_graph_t& _graph,
 	                              const directed_flag_complex_in_memory_t<std::pair<index_t, value_t>>& _complex,
-	                              size_t* _cell_index_offsets, size_t _total_cell_number, bool _is_first,
-	                              coefficient_t _modulus = 2)
+	                              std::vector<size_t>& _cell_index_offsets, size_t _total_cell_number, bool _is_first,
+	                              const size_t nb_threads, coefficient_t _modulus = 2)
 	    : is_first(_is_first), current_dimension(_current_dimension), coboundary_matrix(_coboundary_matrix),
 	      graph(_graph), complex(_complex), cell_index_offsets(_cell_index_offsets),
-	      total_cell_number(_total_cell_number), modulus(_modulus) {}
+	      total_cell_number(_total_cell_number), nb_threads(nb_threads), modulus(_modulus) {}
 
 	void done() {
 #ifdef INDICATE_PROGRESS
@@ -257,8 +259,7 @@ struct store_coboundaries_in_cache_t {
 #ifdef INDICATE_PROGRESS
 		if (is_first && (current_index + 1) % 10000 == 0) {
 			std::cout << "\033[K"
-			          << "dimension " << current_dimension << ": computed ca. "
-			          << PARALLEL_THREADS * (current_index + 1);
+			          << "dimension " << current_dimension << ": computed ca. " << nb_threads * (current_index + 1);
 			if (total_cell_number > 0) std::cout << "/" << total_cell_number;
 			std::cout << " coboundaries" << std::flush << "\r";
 		}
@@ -293,7 +294,7 @@ struct store_coboundaries_in_cache_t {
 
 					// Now insert the appropriate vertex at this position
 					auto cb = cell.insert_vertex(i, vertex_index_t(vertex_offset + b));
-					short thread_index = cb.vertex(0) % PARALLEL_THREADS;
+					short thread_index = cb.vertex(0) % nb_threads;
 					coboundary_matrix.push_back(make_entry(complex.get_data(current_dimension + 1, cb).first +
 					                                           index_t(cell_index_offsets[thread_index]),
 					                                       index_t(i & 1 ? -1 + modulus : 1)));
@@ -311,8 +312,9 @@ private:
 	compressed_sparse_matrix<entry_t>& coboundary_matrix;
 	const filtered_directed_graph_t& graph;
 	const directed_flag_complex_in_memory_t<std::pair<index_t, value_t>>& complex;
-	size_t* cell_index_offsets;
+	std::vector<size_t>& cell_index_offsets;
 	size_t total_cell_number;
+	const size_t nb_threads;
 	coefficient_t modulus;
 };
 
@@ -323,12 +325,12 @@ void directed_flag_complex_in_memory_computer_t::prepare_next_dimension(int dime
 	current_dimension = dimension;
 	cell_count.resize(dimension + 2);
 
-	for (int i = 0; i < PARALLEL_THREADS; i++) { coboundary_matrix[i].clear(); }
+	for (size_t i = 0; i < nb_threads; i++) { coboundary_matrix[i].clear(); }
 
 	if (dimension > max_dimension || _is_top_dimension) return;
 
 	{
-		size_t _next_cells_offsets[PARALLEL_THREADS];
+		std::vector<size_t> _next_cells_offsets(nb_threads, 0);
 		{
 			// If we will actually compute coboundaries, then compute the filtration.
 			// Also if we need the face filtrations.
@@ -340,13 +342,13 @@ void directed_flag_complex_in_memory_computer_t::prepare_next_dimension(int dime
 				          << (dimension + 1) << "-dimensional cells" << std::flush << "\r";
 #endif
 				std::vector<compute_filtration_t> compute_filtration;
-				for (int i = 0; i < PARALLEL_THREADS; i++) {
+				for (size_t i = 0; i < nb_threads; i++) {
 					compute_filtration.push_back(compute_filtration_t(filtration_algorithm, graph, flag_complex));
 				}
 				flag_complex.for_each_cell(compute_filtration, dimension + 1);
 
 				size_t _cell_count = 0;
-				for (int i = 0; i < PARALLEL_THREADS; i++) {
+				for (size_t i = 0; i < nb_threads; i++) {
 					_next_cells_offsets[i] = _cell_count;
 					_cell_count += compute_filtration[i].number_of_cells();
 				}
@@ -357,7 +359,7 @@ void directed_flag_complex_in_memory_computer_t::prepare_next_dimension(int dime
 					// Combine the filtration
 					next_filtration.clear();
 					next_filtration.reserve(_cell_count);
-					for (int i = 0; i < PARALLEL_THREADS; i++) {
+					for (size_t i = 0; i < nb_threads; i++) {
 						for (auto f : compute_filtration[i].filtration()) next_filtration.push_back(f);
 					}
 				}
@@ -377,16 +379,16 @@ void directed_flag_complex_in_memory_computer_t::prepare_next_dimension(int dime
 
 			// Now compute the coboundaries
 			std::vector<store_coboundaries_in_cache_t> store_coboundaries;
-			for (int i = 0; i < PARALLEL_THREADS; i++) coboundary_matrix[i] = compressed_sparse_matrix<entry_t>();
-			for (int i = 0; i < PARALLEL_THREADS; i++) {
-				store_coboundaries.push_back(
-				    store_coboundaries_in_cache_t(coboundary_matrix[i], dimension, graph, flag_complex,
-				                                  _next_cells_offsets, int(cell_count[dimension]), i == 0, modulus));
+			for (size_t i = 0; i < nb_threads; i++) coboundary_matrix[i] = compressed_sparse_matrix<entry_t>();
+			for (size_t i = 0; i < nb_threads; i++) {
+				store_coboundaries.push_back(store_coboundaries_in_cache_t(
+				    coboundary_matrix[i], dimension, graph, flag_complex, _next_cells_offsets,
+				    int(cell_count[dimension]), i == 0, nb_threads, modulus));
 			}
 			flag_complex.for_each_cell(store_coboundaries, dimension);
 
 			size_t _cell_count = 0;
-			for (int i = 0; i < PARALLEL_THREADS; i++) {
+			for (size_t i = 0; i < nb_threads; i++) {
 				coboundary_matrix_offsets[i] = _cell_count;
 				_cell_count += coboundary_matrix[i].size();
 			}

--- a/include/complex/directed_flag_complex_in_memory_computer.h
+++ b/include/complex/directed_flag_complex_in_memory_computer.h
@@ -179,10 +179,10 @@ class directed_flag_complex_in_memory_computer_t {
 
 public:
 	directed_flag_complex_in_memory_computer_t(filtered_directed_graph_t& _graph, const flagser_parameters& params)
-	    : graph(_graph), flag_complex(graph, params.nb_threads), filtration_algorithm(params.filtration_algorithm.get()),
-	      min_dimension(params.min_dimension), max_dimension(params.max_dimension), cache(params.cache.c_str()),
-	      nb_threads(params.nb_threads), coboundary_matrix(nb_threads), coboundary_matrix_offsets(nb_threads, 0),
-	      modulus(params.modulus) {
+	    : graph(_graph), flag_complex(graph, params.nb_threads),
+	      filtration_algorithm(params.filtration_algorithm.get()), min_dimension(params.min_dimension),
+	      max_dimension(params.max_dimension), cache(params.cache.c_str()), nb_threads(params.nb_threads),
+	      coboundary_matrix(nb_threads), coboundary_matrix_offsets(nb_threads, 0), modulus(params.modulus) {
 		cell_count.push_back(_graph.vertex_number());
 		cell_count.push_back(_graph.edge_number());
 

--- a/include/definitions.h
+++ b/include/definitions.h
@@ -6,7 +6,6 @@
 #include <unordered_map>
 
 // #define USE_GOOGLE_HASHMAP
-#define PARALLEL_THREADS 8
 
 #ifndef MANY_VERTICES
 // Assume that we have at most 65k vertices, and that there are at most ~2 billion cells

--- a/include/filtration_algorithms.h
+++ b/include/filtration_algorithms.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <exception>
 #include <math.h>
 
 #include "complex/directed_flag_complex.h"
@@ -66,6 +67,6 @@ filtration_algorithm_t* get_filtration_computer(std::string algorithm) {
 
 	if (custom != nullptr) return custom;
 
-	std::cerr << "The filtration algorithm \"" << algorithm << "\" could not be found." << std::endl;
-	exit(-1);
+	std::string err_msg = "The filtration algorithm \"" + algorithm + "\" could not be found.";
+	throw std::invalid_argument(err_msg);
 }

--- a/include/input/base.h
+++ b/include/input/base.h
@@ -11,8 +11,8 @@
 void open_file(const std::string filename, std::ifstream& file_stream) {
 	file_stream.open(filename);
 	if (file_stream.fail()) {
-		std::cerr << "couldn't open file " << filename << std::endl;
-		exit(-1);
+		std::string err_msg = "couldn't open file " + filename;
+		throw std::runtime_error(err_msg);
 	}
 }
 

--- a/include/input/flagser.h
+++ b/include/input/flagser.h
@@ -66,12 +66,14 @@ filtered_directed_graph_t read_graph_flagser(const std::string filename, const f
 				std::vector<value_t> vertices = split<value_t>(line, ' ', string_to_float);
 				if (value_t(vertices[2]) <
 				    std::max(vertex_filtration[size_t(vertices[0])], vertex_filtration[size_t(vertices[1])])) {
-					std::cerr << "The flagser file contained an edge filtration that contradicts the vertex "
-					             "filtration, the edge ("
-					          << vertices[0] << ", " << vertices[1] << ") has filtration value " << vertices[2]
-					          << ", which is lower than min(" << vertex_filtration[size_t(vertices[0])] << ", "
-					          << vertex_filtration[size_t(vertices[1])] << "), the filtrations of its vertices.";
-					exit(-1);
+					std::string err_msg =
+					    "The flagser file contained an edge filtration that contradicts the vertex "
+					    "filtration, the edge (" +
+					    std::to_string(vertices[0]) + ", " + std::to_string(vertices[1]) + ") has filtration value " +
+					    std::to_string(vertices[2]) + ", which is lower than min(" +
+					    std::to_string(vertex_filtration[size_t(vertices[0])]) + ", " +
+					    std::to_string(vertex_filtration[size_t(vertices[1])]) + "), the filtrations of its vertices.";
+					throw std::runtime_error(err_msg);
 				}
 				graph.add_filtered_edge((vertex_index_t)vertices[0], (vertex_index_t)vertices[1], vertices[2]);
 			}

--- a/include/input/h5.h
+++ b/include/input/h5.h
@@ -5,10 +5,9 @@
 #ifndef WITH_HDF5
 
 filtered_directed_graph_t read_graph_h5(const std::string, const flagser_parameters&) {
-	std::cerr << "Error: flagser was compiled without support for .h5-files. Please install the HDF5-library "
-	             "(https://support.hdfgroup.org/HDF5/) and rebuild flagser by running \"make\" again."
-	          << std::endl;
-	exit(-1);
+	std::string err_msg = "Error: flagser was compiled without support for .h5-files. Please install the HDF5-library "
+	                      "(https://support.hdfgroup.org/HDF5/) and rebuild flagser by running \"make\" again.";
+	throw std::runtime_error(err_msg);
 }
 
 #else
@@ -86,9 +85,8 @@ const filtered_directed_graph_t read_graph_h5(const std::string filename, const 
 	}
 
 	if (!H5Fis_hdf5(fname.c_str())) {
-		std::cerr << "The file \"" << fname << "\" is not an HDF5-file. Please choose another input format."
-		          << std::endl;
-		exit(-1);
+		std::string err_msg = "The file \"" + fname + "\" is not an HDF5-file. Please choose another input format.";
+		throw std::invalid_argument(err_msg);
 	}
 
 	auto file_id = H5Fopen(fname.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
@@ -97,9 +95,9 @@ const filtered_directed_graph_t read_graph_h5(const std::string filename, const 
 		auto dataset_id = H5Dopen(file_id, h5_path.c_str(), H5P_DEFAULT);
 
 		if (dataset_id == -1) {
-			std::cerr << "\n\nThe connectivity data could not be found at \"" << h5_path
-			          << "\", please check the path again." << std::endl;
-			exit(1);
+			std::string err_msg =
+			    "\n\nThe connectivity data could not be found at \"" + h5_path + "\", please check the path again.";
+			throw std::runtime_error(err_msg);
 		}
 
 		// Read the number of vertices
@@ -161,9 +159,9 @@ const filtered_directed_graph_t read_graph_h5(const std::string filename, const 
 
 		auto connectivity_id = H5Gopen(file_id, h5_path.c_str(), H5P_DEFAULT);
 		if (connectivity_id == -1) {
-			std::cerr << "\n\nThe connectivity data could not be found at \"" << h5_path
-			          << "\", please check the path again." << std::endl;
-			exit(1);
+			std::string err_msg =
+			    "\n\nThe connectivity data could not be found at \"" + h5_path + "\", please check the path again.";
+			throw std::runtime_error(err_msg);
 		}
 
 		group_extractor_t group_extractor(groups);
@@ -181,9 +179,9 @@ const filtered_directed_graph_t read_graph_h5(const std::string filename, const 
 			auto dataset_id = H5Dopen(connectivity_id, name.c_str(), H5P_DEFAULT);
 
 			if (dataset_id == -1) {
-				std::cerr << "\n\nThe connectivity data could not be found at \"" << h5_path
-				          << "\", please check the path again." << std::endl;
-				exit(1);
+				std::string err_msg =
+				    "\n\nThe connectivity data could not be found at \"" + h5_path + "\", please check the path again.";
+				throw std::runtime_error(err_msg);
 			}
 
 			auto space = H5Dget_space(dataset_id);

--- a/include/input/input_classes.h
+++ b/include/input/input_classes.h
@@ -28,8 +28,8 @@ filtered_directed_graph_t read_filtered_directed_graph(std::string input_filenam
 	std::cout << "\033[K";
 #endif
 
-	std::cerr << "The input format \"" << params.input_format << "\" could not be found." << std::endl;
-	exit(1);
+	std::string err_msg = "The input format \"" + params.input_format + "\" could not be found.";
+	throw std::invalid_argument(err_msg);
 }
 
 std::vector<std::string> available_input_formats = {"flagser", "h5"};

--- a/include/output/base.h
+++ b/include/output/base.h
@@ -30,14 +30,14 @@ public:
 
 		std::ifstream f(filename);
 		if (f.good()) {
-			std::cerr << "The output file already exists, aborting." << std::endl;
-			exit(-1);
+			std::string err_msg = "The output file already exists, aborting.";
+			throw std::invalid_argument(err_msg);
 		}
 
 		outstream.open(filename);
 		if (outstream.fail()) {
-			std::cerr << "couldn't open file " << filename << std::endl;
-			exit(-1);
+			std::string err_msg = "couldn't open file " + filename;
+			throw std::runtime_error(err_msg);
 		}
 	}
 

--- a/include/output/hdf5_helper.h
+++ b/include/output/hdf5_helper.h
@@ -32,8 +32,8 @@ std::pair<hid_t, hid_t> open_or_create_group(const std::string& filename) {
 	}
 
 	if (file_id == -1) {
-		std::cerr << "The output file " << fname << " could not be opened." << std::endl;
-		exit(-1);
+		std::string err_msg = "The output file " + fname + " could not be opened.";
+		throw std::invalid_argument(err_msg);
 	}
 
 	// Suppress errors
@@ -49,8 +49,8 @@ std::pair<hid_t, hid_t> open_or_create_group(const std::string& filename) {
 		hid_t new_group_id = H5Gopen2(group_id, group.c_str(), H5P_DEFAULT);
 		if (new_group_id < 0) new_group_id = H5Gcreate2(group_id, group.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 		if (new_group_id < 0) {
-			std::cerr << "Could not create group " << group << "." << std::endl;
-			exit(-1);
+			std::string err_msg = "Could not create group " + group + ".";
+			throw std::invalid_argument(err_msg);
 		}
 		group_id = new_group_id;
 	}
@@ -62,8 +62,8 @@ std::pair<hid_t, hid_t> open_or_create_group(const std::string& filename) {
 	H5Eset_auto2(H5P_DEFAULT, old_func, old_client_data);
 
 	if (group_id < 0) {
-		std::cerr << "The data could not be written to " << h5_path << "." << std::endl;
-		exit(-1);
+		std::string err_msg = "The data could not be written to " + h5_path + ".";
+		throw std::invalid_argument(err_msg);
 	}
 
 	return std::make_pair(file_id, group_id);

--- a/include/output/output_classes.h
+++ b/include/output/output_classes.h
@@ -42,8 +42,8 @@ template <typename Complex> std::unique_ptr<output_t<Complex>> get_output(const 
 	if (params.output_format == "barcode:hdf5") return make_unique<barcode_hdf5_output_t<Complex>>(params);
 #endif
 
-	std::cerr << "The output format \"" << params.output_format << "\" could not be found." << std::endl;
-	exit(1);
+	std::string err_msg = "The output format \"" + params.output_format + "\" could not be found.";
+	throw std::invalid_argument(err_msg);
 }
 
 std::vector<std::string> available_output_formats = {"barcode", "betti"

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -6,13 +6,12 @@
 #include "filtration_algorithms.h"
 
 #include <cstring>
+#include <thread>
 
 /* Avoid name collision with generic name parameters*/
 class flagser_parameters {
 public:
-    flagser_parameters() {
-        filtration_algorithm.reset(get_filtration_computer("zero"));
-    }
+	flagser_parameters() { filtration_algorithm.reset(get_filtration_computer("zero")); }
 	flagser_parameters(const named_arguments_t& named_arguments) {
 		named_arguments_t::const_iterator it;
 
@@ -41,10 +40,12 @@ public:
 		filtration_algorithm.reset(
 		    get_filtration_computer(get_argument_or_default(named_arguments, "filtration", "zero")));
 
-        if ((it = named_arguments.find("threshold")) != named_arguments.end()) {
-            std::string parameter = std::string(it->second);
-            threshold = std::stof(parameter, nullptr);
-        }
+		if ((it = named_arguments.find("threshold")) != named_arguments.end()) {
+			std::string parameter = std::string(it->second);
+			threshold = std::stof(parameter, nullptr);
+		}
+
+		if ((it = named_arguments.find("threads")) != named_arguments.end()) { nb_threads = atoi(it->second); }
 
 #ifdef USE_COEFFICIENTS
 		if ((it = named_arguments.find("modulus")) != named_arguments.end()) { modulus = atoi(it->second); }
@@ -59,6 +60,7 @@ public:
 	bool directed = false;
 	bool approximate_computation = false;
 	size_t max_entries = std::numeric_limits<size_t>::max();
+	size_t nb_threads = std::thread::hardware_concurrency();
 	std::string input_format = "flagser";
 	std::string output_name = "";
 	std::string output_format = "barcode";

--- a/include/usage/homology.h
+++ b/include/usage/homology.h
@@ -20,7 +20,7 @@ void print_homology_usage(bool no_filtration = false) {
 #endif
 	          << "  --approximate n    skip all columns creating columns in the reduction matrix with" << std::endl
 	          << "                     n non-trivial entries. Use this for hard problems, a good value" << std::endl
-	          << "                     is often 100000. Increase for higher precision, decrease for faster computation."
+	          << "                     is often 100000. Increase for higher precision, decrease for faster computation." << std::endl
 	          << "  --threads          number of threads to use for the computation (default: number of threads that your machine can execute simultaneously)" << std::endl
 	          << std::endl;
 }

--- a/include/usage/homology.h
+++ b/include/usage/homology.h
@@ -21,5 +21,6 @@ void print_homology_usage(bool no_filtration = false) {
 	          << "  --approximate n    skip all columns creating columns in the reduction matrix with" << std::endl
 	          << "                     n non-trivial entries. Use this for hard problems, a good value" << std::endl
 	          << "                     is often 100000. Increase for higher precision, decrease for faster computation."
+	          << "  --threads          number of threads to use for the computation (default: number of threads that your machine can execute simultaneously)" << std::endl
 	          << std::endl;
 }

--- a/parser/math_parser.py
+++ b/parser/math_parser.py
@@ -83,8 +83,7 @@ math_parser = Lark(r"""
 
 def print_error_message(expression):
     return """
-            std::cerr << {error_msg} << std::endl;
-            exit(-1);
+            throw std::runtime_error({error_msg});
     """.format(error_msg=expression.children[0])
 
 

--- a/src/flagser-count.cpp
+++ b/src/flagser-count.cpp
@@ -93,8 +93,8 @@ std::vector<size_t> count_cells(filtered_directed_graph_t& graph, const flagser_
 			std::vector<size_t> cell_counts;
 		};
 
-		std::vector<cell_counter_t> cell_counter(PARALLEL_THREADS);
-		for (int i = 0; i < PARALLEL_THREADS; i++)
+		std::vector<cell_counter_t> cell_counter(params.nb_threads);
+		for (size_t i = 0; i < params.nb_threads; i++)
 			cell_counter[i] = cell_counter_t(
 #ifdef WITH_HDF5
 			    output
@@ -111,7 +111,7 @@ std::vector<size_t> count_cells(filtered_directed_graph_t& graph, const flagser_
 		}
 #endif
 		int64_t euler_characteristic = 0;
-		for (int i = 0; i < PARALLEL_THREADS; i++) euler_characteristic += cell_counter[i].euler_characteristic();
+		for (size_t i = 0; i < params.nb_threads; i++) euler_characteristic += cell_counter[i].euler_characteristic();
 
 #ifdef INDICATE_PROGRESS
 		std::cout << "\033[K";
@@ -120,9 +120,9 @@ std::vector<size_t> count_cells(filtered_directed_graph_t& graph, const flagser_
 		if (is_first_line) std::cout << "# [euler_characteristic cell_count_dim_0 cell_count_dim_1 ...]" << std::endl;
 		std::cout << euler_characteristic;
 
-		std::array<std::vector<size_t>, PARALLEL_THREADS> cell_counts;
+		std::vector<std::vector<size_t>> cell_counts(params.nb_threads);
 		size_t max_dim = 0;
-		for (int i = 0; i < PARALLEL_THREADS; i++) {
+		for (size_t i = 0; i < params.nb_threads; i++) {
 			cell_counts[i] = cell_counter[i].cell_count();
 			size_t dim = cell_counts[i].size();
 			max_dim = max_dim < dim ? dim : max_dim;
@@ -131,7 +131,7 @@ std::vector<size_t> count_cells(filtered_directed_graph_t& graph, const flagser_
 		total_cell_count.resize(max_dim, 0);
 		for (size_t dim = 0; dim < max_dim; dim++) {
 			size_t size = 0;
-			for (int i = 0; i < PARALLEL_THREADS; i++) size += cell_counts[i].size() > dim ? cell_counts[i][dim] : 0;
+			for (size_t i = 0; i < params.nb_threads; i++) size += cell_counts[i].size() > dim ? cell_counts[i][dim] : 0;
 			std::cout << " " << size;
 			total_cell_count[dim] += size;
 		}

--- a/src/flagser-count.cpp
+++ b/src/flagser-count.cpp
@@ -131,7 +131,8 @@ std::vector<size_t> count_cells(filtered_directed_graph_t& graph, const flagser_
 		total_cell_count.resize(max_dim, 0);
 		for (size_t dim = 0; dim < max_dim; dim++) {
 			size_t size = 0;
-			for (size_t i = 0; i < params.nb_threads; i++) size += cell_counts[i].size() > dim ? cell_counts[i][dim] : 0;
+			for (size_t i = 0; i < params.nb_threads; i++)
+				size += cell_counts[i].size() > dim ? cell_counts[i][dim] : 0;
 			std::cout << " " << size;
 			total_cell_count[dim] += size;
 		}
@@ -157,18 +158,20 @@ std::vector<size_t> count_cells(filtered_directed_graph_t& graph, const flagser_
 }
 
 int main(int argc, char** argv) {
-	auto arguments = parse_arguments(argc, argv);
+	try {
+		auto arguments = parse_arguments(argc, argv);
 
-	auto positional_arguments = get_positional_arguments(arguments);
-	auto named_arguments = get_named_arguments(arguments);
-	auto params = flagser_parameters(named_arguments);
-	named_arguments_t::const_iterator it;
-	if (named_arguments.find("help") != named_arguments.end()) { print_usage_and_exit(-1); }
+		auto positional_arguments = get_positional_arguments(arguments);
+		auto named_arguments = get_named_arguments(arguments);
+		auto params = flagser_parameters(named_arguments);
+		named_arguments_t::const_iterator it;
+		if (named_arguments.find("help") != named_arguments.end()) { print_usage_and_exit(-1); }
 
-	if (positional_arguments.size() == 0) { print_usage_and_exit(-1); }
-	const char* input_filename = positional_arguments[0];
+		if (positional_arguments.size() == 0) { print_usage_and_exit(-1); }
+		const char* input_filename = positional_arguments[0];
 
-	filtered_directed_graph_t graph = read_filtered_directed_graph(input_filename, params);
+		filtered_directed_graph_t graph = read_filtered_directed_graph(input_filename, params);
 
-	auto cell_count = count_cells(graph, params);
+		auto cell_count = count_cells(graph, params);
+	} catch (const std::exception& e) { std::cout << e.what() << std::endl; }
 }

--- a/src/flagser.cpp
+++ b/src/flagser.cpp
@@ -89,18 +89,22 @@ compute_homology(filtered_directed_graph_t& graph, const flagser_parameters& par
 }
 
 int main(int argc, char** argv) {
-	auto arguments = parse_arguments(argc, argv);
+	try {
+		auto arguments = parse_arguments(argc, argv);
 
-	auto positional_arguments = get_positional_arguments(arguments);
-	auto named_arguments = get_named_arguments(arguments);
-	auto params = flagser_parameters(named_arguments);
+		auto positional_arguments = get_positional_arguments(arguments);
+		auto named_arguments = get_named_arguments(arguments);
+		auto params = flagser_parameters(named_arguments);
 
-	if (named_arguments.find("help") != named_arguments.end()) { print_usage_and_exit(-1); }
+		std::cout << params.nb_threads << std::endl;
 
-	if (positional_arguments.size() == 0) { print_usage_and_exit(-1); }
-	const char* input_filename = positional_arguments[0];
+		if (named_arguments.find("help") != named_arguments.end()) { print_usage_and_exit(-1); }
 
-	filtered_directed_graph_t graph = read_filtered_directed_graph(input_filename, params);
+		if (positional_arguments.size() == 0) { print_usage_and_exit(-1); }
+		const char* input_filename = positional_arguments[0];
 
-	compute_homology(graph, params);
+		filtered_directed_graph_t graph = read_filtered_directed_graph(input_filename, params);
+
+		compute_homology(graph, params);
+	} catch (const std::exception& e) { std::cout << e.what() << std::endl; }
 }


### PR DESCRIPTION
Hi !

This PR update the code as follow:

* Now `--threads <N>` argument was added in order to let the users indicate with how many threads we want to run the execution. If the argument is not specified, it will take the value of `std::thread::hardware_concurrency()`
* Now from most part of the code, instead of calling `exit` to stop the program execution, an exception is thrown. The python bindings developed in `pyflagser` needs to manage an exception instead of the C++ code calling `exit`. (@gtauzin raised this issue when discussing with me).

One observation on the windows compilation, on my computer when trying to compile with Windows, with `hdf5` enable, the compilation fails because it cannot find `pthread`. I don't know what could be the best way to manage this, maybe disabling `hdf5` support on windows ?

Feel free to use a better exception if you feel I didn't use the correct one, I tried to use the one I found fittest the best to the situation, but I can be wrong :).